### PR TITLE
Implement get /fn

### DIFF
--- a/src/main/java/seedu/address/logic/commands/GetFloorNumberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GetFloorNumberCommand.java
@@ -1,5 +1,9 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.FloorNumberContainsKeywordsPredicate;
@@ -7,17 +11,17 @@ import seedu.address.model.person.PatientType;
 import seedu.address.model.person.PatientTypePredicate;
 import seedu.address.model.person.Person;
 
-import java.util.function.Predicate;
-
-import static java.util.Objects.requireNonNull;
-
+/**
+ * Finds and lists all patients within all given floor numbers separated by a whitespace.
+ * Integers must be positive.
+ */
 public class GetFloorNumberCommand extends Command {
     public static final String COMMAND_WORD = "get";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all patients within the same floor number"
             + "and displays them as a list with index numbers.\n"
             + "Parameters: FLOOR_NUMBER (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " /fn 10";
+            + "Example: " + COMMAND_WORD + " /fn 10 4 3";
 
     private final FloorNumberContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/GetFloorNumberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GetFloorNumberCommand.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.FloorNumberContainsKeywordsPredicate;
+import seedu.address.model.person.PatientType;
+import seedu.address.model.person.PatientTypePredicate;
+import seedu.address.model.person.Person;
+
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+
+public class GetFloorNumberCommand extends Command {
+    public static final String COMMAND_WORD = "get";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all patients within the same floor number"
+            + "and displays them as a list with index numbers.\n"
+            + "Parameters: FLOOR_NUMBER (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " /fn 10";
+
+    private final FloorNumberContainsKeywordsPredicate predicate;
+
+    public GetFloorNumberCommand(FloorNumberContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        PatientTypePredicate patientTypePredicate = new PatientTypePredicate(PatientType.PatientTypes.INPATIENT);
+        Predicate<Person> inPatientFloorNumberPredicate = patientTypePredicate.and(predicate);
+        model.updateFilteredPersonList(inPatientFloorNumberPredicate);
+
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof GetFloorNumberCommand // instanceof handles nulls
+                && predicate.equals(((GetFloorNumberCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -2,10 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_HOSPITAL_WING_PARSER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INPATIENT_PARSER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME_PARSER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_OUTPATIENT_PARSER;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,7 +32,7 @@ public class AddressBookParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Pattern GET_COMMAND_FORMAT = Pattern
-            .compile("(?<commandWord>[get\\s]+)(?<prefix>[/a-z]+)(?<arguments>[a-zA-Z0-9\\s]*)");
+            .compile("(?<commandWord>[get\\s]+)(?<prefix>[/a-z]+)(?<arguments>[a-zA-Z-0-9\\s]*)");
 
     /**
      * Parses user input into command for execution.
@@ -55,6 +52,10 @@ public class AddressBookParser {
 
             if (prefixes.equals(PREFIX_HOSPITAL_WING_PARSER)) {
                 return new GetHospitalWingCommandParser().parse(arguments);
+            }
+
+            if (prefixes.equals(PREFIX_FLOOR_NUMBER_PARSER)) {
+                return new GetFloorNumberParser().parse(arguments);
             }
 
             if (prefixes.equals(PREFIX_NAME_PARSER)) {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -2,7 +2,11 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FLOOR_NUMBER_PARSER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_HOSPITAL_WING_PARSER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INPATIENT_PARSER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME_PARSER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_OUTPATIENT_PARSER;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -20,7 +24,6 @@ import seedu.address.logic.commands.GetOutpatientCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-
 
 /**
  * Parses user input.

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -17,6 +17,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_HOSPITAL_WING = new Prefix("hw/");
     public static final Prefix PREFIX_HOSPITAL_WING_PARSER = new Prefix("/hw");
     public static final Prefix PREFIX_FLOOR_NUMBER = new Prefix("fn/");
+    public static final Prefix PREFIX_FLOOR_NUMBER_PARSER = new Prefix("/fn");
     public static final Prefix PREFIX_WARD_NUMBER = new Prefix("wn/");
     public static final Prefix PREFIX_MEDICATION = new Prefix("m/");
 

--- a/src/main/java/seedu/address/logic/parser/GetFloorNumberParser.java
+++ b/src/main/java/seedu/address/logic/parser/GetFloorNumberParser.java
@@ -1,15 +1,18 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import seedu.address.logic.commands.GetFloorNumberCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.FloorNumberContainsKeywordsPredicate;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
+/**
+ * Parses input arguments and creates a new GetFloorNumberCommand object
+ */
 public class GetFloorNumberParser implements Parser<GetFloorNumberCommand> {
 
     /**

--- a/src/main/java/seedu/address/logic/parser/GetFloorNumberParser.java
+++ b/src/main/java/seedu/address/logic/parser/GetFloorNumberParser.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.GetFloorNumberCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.FloorNumber;
+import seedu.address.model.person.FloorNumberContainsKeywordsPredicate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+public class GetFloorNumberParser implements Parser<GetFloorNumberCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the GetFloorNumberCommand
+     * and returns a GetFloorNumberCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public GetFloorNumberCommand parse(String userInput) throws ParseException {
+        String trimmedArgs = userInput.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, GetFloorNumberCommand.MESSAGE_USAGE));
+        }
+        List<FloorNumber> floorNumbers = new ArrayList<>();
+        for (String arg : trimmedArgs.split("\\s+")) {
+            try {
+                floorNumbers.add(new FloorNumber(Integer.parseInt(arg)));
+            } catch (IllegalArgumentException e) { // Catches both String input and negative number errors.
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, GetFloorNumberCommand.MESSAGE_USAGE));
+            }
+        }
+        return new GetFloorNumberCommand(new FloorNumberContainsKeywordsPredicate(floorNumbers));
+    }
+}

--- a/src/main/java/seedu/address/model/person/FloorNumberContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FloorNumberContainsKeywordsPredicate.java
@@ -1,0 +1,25 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+import java.util.List;
+
+public class FloorNumberContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<FloorNumber> floorNumbers;
+
+    public FloorNumberContainsKeywordsPredicate(List<FloorNumber> floorNumbers) {
+        this.floorNumbers = floorNumbers;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return floorNumbers.stream()
+                .anyMatch(floorNumber -> person.getFloorNumber().get().equals(floorNumber));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FloorNumberContainsKeywordsPredicate // instanceof handles nulls
+                && floorNumbers.equals(((FloorNumberContainsKeywordsPredicate) other).floorNumbers)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/person/FloorNumberContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FloorNumberContainsKeywordsPredicate.java
@@ -1,8 +1,11 @@
 package seedu.address.model.person;
 
-import java.util.function.Predicate;
 import java.util.List;
+import java.util.function.Predicate;
 
+/**
+ * Tests that a {@code Person}'s {@code Floor Number} matches any of the floor numbers given.
+ */
 public class FloorNumberContainsKeywordsPredicate implements Predicate<Person> {
     private final List<FloorNumber> floorNumbers;
 


### PR DESCRIPTION
Implement `get /fn` command, accepting multiple inputs of floor numbers, separated by whitespace.
Handles following errors:
- Negative floor number inputs
- Character inputs (Impure integers)

Extra changes made to regex to accept negative numbers so as to throw appropriate error messages when parsing negative floor number values.
Future iterations could introduce testing for this new command.

Close #6.