### PR TITLE
Implement appointment feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CreatePastAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreatePastAppointmentCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DIAGNOSIS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICATION;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.appointment.PastAppointment;
+import seedu.address.model.person.Person;
+
+/**
+ * Creates a past appointment for a patient.
+ */
+public class CreatePastAppointmentCommand extends Command {
+    public static final String COMMAND_WORD = "appt";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Creates a past appointment for a patient.\n"
+            + "Parameters: INDEX (Must be a positive integer) "
+            + PREFIX_DATE + "DATE (Must follow dd-mm-yyyy syntax) "
+            + PREFIX_MEDICATION + "MEDICATION "
+            + PREFIX_DIAGNOSIS + "DIAGNOSIS \n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_DATE + "01-01-2001 "
+            + PREFIX_MEDICATION + "ibuprofen "
+            + PREFIX_DIAGNOSIS + "headache, medicine given for 3 days ";
+    public static final String MESSAGE_SUCCESS = "Past appointment created: %1$s";
+    public static final String MESSAGE_NOT_CREATED = "Missing fields, please try again!";
+    private final Index index;
+    private final PastAppointment appt;
+
+    /**
+     * Creates a command to add past appointments to a patient's record.
+     * @param index of the patient in the filtered patient list to edit
+     */
+    public CreatePastAppointmentCommand(Index index, PastAppointment appt) {
+        requireNonNull(index);
+        this.index = index;
+        this.appt = appt;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        Person patient = lastShownList.get(index.getZeroBased());
+        return new CommandResult(String.format(MESSAGE_SUCCESS, appt));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CreatePastAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreatePastAppointmentCommand.java
@@ -29,7 +29,7 @@ public class CreatePastAppointmentCommand extends Command {
             + PREFIX_DATE + "01-01-2001 "
             + PREFIX_MEDICATION + "ibuprofen "
             + PREFIX_DIAGNOSIS + "headache, medicine given for 3 days ";
-    public static final String MESSAGE_SUCCESS = "Past appointment created: %1$s";
+    public static final String MESSAGE_SUCCESS = "Past appointment created for %1$s.\n";
     public static final String MESSAGE_NOT_CREATED = "Missing fields, please try again!";
     private final Index index;
     private final PastAppointment appt;
@@ -52,6 +52,7 @@ public class CreatePastAppointmentCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
         Person patient = lastShownList.get(index.getZeroBased());
-        return new CommandResult(String.format(MESSAGE_SUCCESS, appt));
+        patient.addPastAppointment(appt);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, patient.getName()) + appt);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_UPCOMING_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WARD_NUMBER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -24,6 +25,7 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointment.PastAppointment;
+import seedu.address.model.appointment.UpcomingAppointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.HospitalWing;
@@ -54,6 +56,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_HOSPITAL_WING + "HOSPITAL WING] "
             + "[" + PREFIX_FLOOR_NUMBER + "FLOOR NUMBER] "
             + "[" + PREFIX_WARD_NUMBER + "WARD NUMBER] "
+            + "[" + PREFIX_UPCOMING_APPOINTMENT + "UPCOMING APPOINTMENT DATE] "
             + "[" + PREFIX_MEDICATION + "MEDICATION]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -131,9 +134,12 @@ public class EditCommand extends Command {
         Set<Medication> updatedMedications = editPersonDescriptor.getMedications()
                 .orElse(personToEdit.getMedications());
         List<PastAppointment> pastAppointments = personToEdit.getPastAppointments();
+        UpcomingAppointment updatedUpcomingAppointment = editPersonDescriptor.getUpcomingAppointment()
+                .orElse(personToEdit.getUpcomingAppointment().orElse(null));
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedNextOfKin, updatedPatientType,
-                updatedHospitalWing, updatedFloorNumber, updatedWardNumber, updatedMedications, pastAppointments);
+                updatedHospitalWing, updatedFloorNumber, updatedWardNumber, updatedMedications, pastAppointments,
+                updatedUpcomingAppointment);
     }
 
     @Override
@@ -168,6 +174,7 @@ public class EditCommand extends Command {
         private FloorNumber floorNumber;
         private WardNumber wardNumber;
         private Set<Medication> medications;
+        private UpcomingAppointment upcomingAppointment;
 
         public EditPersonDescriptor() {}
 
@@ -185,6 +192,7 @@ public class EditCommand extends Command {
             setFloorNumber(toCopy.floorNumber);
             setWardNumber(toCopy.wardNumber);
             setMedications(toCopy.medications);
+            setUpcomingAppointment(toCopy.upcomingAppointment);
         }
 
         /**
@@ -192,7 +200,7 @@ public class EditCommand extends Command {
          */
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(name, phone, email, nextOfKin, patientType,
-                    hospitalWing, floorNumber, wardNumber, medications);
+                    hospitalWing, floorNumber, wardNumber, medications, upcomingAppointment);
         }
 
         public void setName(Name name) {
@@ -276,6 +284,13 @@ public class EditCommand extends Command {
             return (medications != null) ? Optional.of(Collections.unmodifiableSet(medications)) : Optional.empty();
         }
 
+        public void setUpcomingAppointment(UpcomingAppointment upcomingAppointment) {
+            this.upcomingAppointment = upcomingAppointment;
+        }
+
+        public Optional<UpcomingAppointment> getUpcomingAppointment() {
+            return Optional.ofNullable(upcomingAppointment);
+        }
         @Override
         public boolean equals(Object other) {
             // short circuit if same object

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -23,6 +23,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.appointment.PastAppointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.HospitalWing;
@@ -129,9 +130,10 @@ public class EditCommand extends Command {
         }
         Set<Medication> updatedMedications = editPersonDescriptor.getMedications()
                 .orElse(personToEdit.getMedications());
+        List<PastAppointment> pastAppointments = personToEdit.getPastAppointments();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedNextOfKin, updatedPatientType,
-                updatedHospitalWing, updatedFloorNumber, updatedWardNumber, updatedMedications);
+                updatedHospitalWing, updatedFloorNumber, updatedWardNumber, updatedMedications, pastAppointments);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WARD_NUMBER;
 
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -71,7 +72,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         Person person = new Person(name, phone, email, nextOfKin, patientType, hospitalWing,
-                floorNumber, wardNumber, medicationList);
+                floorNumber, wardNumber, medicationList, new ArrayList<>());
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.UpcomingAppointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.HospitalWing;
@@ -71,8 +72,10 @@ public class AddCommandParser implements Parser<AddCommand> {
             wardNumber = ParserUtil.parseWardNumber(argMultimap.getValue(PREFIX_WARD_NUMBER).get());
         }
 
+        UpcomingAppointment upcomingAppointment = null;
+
         Person person = new Person(name, phone, email, nextOfKin, patientType, hospitalWing,
-                floorNumber, wardNumber, medicationList, new ArrayList<>());
+                floorNumber, wardNumber, medicationList, new ArrayList<>(), upcomingAppointment);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CountCommand;
+import seedu.address.logic.commands.CreatePastAppointmentCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -74,6 +75,9 @@ public class AddressBookParser {
 
             case GetCommand.COMMAND_WORD:
                 return new GetCommandParser().parse(arguments);
+
+            case CreatePastAppointmentCommand.COMMAND_WORD:
+                return new CreatePastAppointmentCommandParser().parse(arguments);
 
             default:
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,6 +15,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_FLOOR_NUMBER = new Prefix("fn/");
     public static final Prefix PREFIX_WARD_NUMBER = new Prefix("wn/");
     public static final Prefix PREFIX_MEDICATION = new Prefix("m/");
+    public static final Prefix PREFIX_DATE = new Prefix("on/");
+    public static final Prefix PREFIX_DIAGNOSIS = new Prefix("diag/");
 
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -17,6 +17,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_MEDICATION = new Prefix("m/");
     public static final Prefix PREFIX_DATE = new Prefix("on/");
     public static final Prefix PREFIX_DIAGNOSIS = new Prefix("diag/");
-
+    public static final Prefix PREFIX_UPCOMING_APPOINTMENT = new Prefix("upcoming/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CreatePastAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreatePastAppointmentCommandParser.java
@@ -40,7 +40,7 @@ public class CreatePastAppointmentCommandParser implements Parser<CreatePastAppo
         Set<Medication> medicationSet = new HashSet<>();
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_MEDICATION)).ifPresent(medicationSet::addAll);
         PastAppointment appt = new PastAppointment(
-                LocalDate.parse(argMultimap.getValue(PREFIX_DATE).get(), DateTimeFormatter.ofPattern("dd-MM-yyyy")),
+                LocalDate.parse(argMultimap.getValue(PREFIX_DATE).get(), DateTimeFormatter.ofPattern("ddMMyy")),
                 medicationSet, argMultimap.getValue(PREFIX_DIAGNOSIS).get());
 
         return new CreatePastAppointmentCommand(index, appt);

--- a/src/main/java/seedu/address/logic/parser/CreatePastAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreatePastAppointmentCommandParser.java
@@ -1,0 +1,64 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DIAGNOSIS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICATION;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CreatePastAppointmentCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.PastAppointment;
+import seedu.address.model.tag.Medication;
+
+/**
+ * Parses input arguments and creates a new CreatePastAppointmentCommand object.
+ */
+public class CreatePastAppointmentCommandParser implements Parser<CreatePastAppointmentCommand> {
+    @Override
+    public CreatePastAppointmentCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_MEDICATION, PREFIX_DATE, PREFIX_DIAGNOSIS);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    CreatePastAppointmentCommand.MESSAGE_USAGE), pe);
+        }
+        Set<Medication> medicationSet = new HashSet<>();
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_MEDICATION)).ifPresent(medicationSet::addAll);
+        PastAppointment appt = new PastAppointment(
+                LocalDate.parse(argMultimap.getValue(PREFIX_DATE).get(), DateTimeFormatter.ofPattern("dd-MM-yyyy")),
+                medicationSet, argMultimap.getValue(PREFIX_DIAGNOSIS).get());
+
+        return new CreatePastAppointmentCommand(index, appt);
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Medication>> parseTagsForEdit(Collection<String> medications) throws ParseException {
+        assert medications != null;
+
+        if (medications.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> medicationSet = medications.size() == 1 && medications.contains("")
+                ? Collections.emptySet() : medications;
+        return Optional.of(ParserUtil.parseMedications(medicationSet));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_UPCOMING_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WARD_NUMBER;
 
 import java.util.Collection;
@@ -39,7 +40,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NEXT_OF_KIN,
                         PREFIX_PATIENT_TYPE, PREFIX_HOSPITAL_WING, PREFIX_FLOOR_NUMBER,
-                        PREFIX_WARD_NUMBER, PREFIX_MEDICATION);
+                        PREFIX_WARD_NUMBER, PREFIX_MEDICATION, PREFIX_UPCOMING_APPOINTMENT);
 
         Index index;
         try {
@@ -77,6 +78,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_WARD_NUMBER).isPresent()) {
             editPersonDescriptor.setWardNumber(ParserUtil.parseWardNumber(
                     argMultimap.getValue(PREFIX_WARD_NUMBER).get()));
+        }
+        if (argMultimap.getValue(PREFIX_UPCOMING_APPOINTMENT).isPresent()) {
+            editPersonDescriptor.setUpcomingAppointment(ParserUtil.parseUpcomingAppointment(
+                    argMultimap.getValue(PREFIX_UPCOMING_APPOINTMENT).get()));
         }
 
         /*

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -9,6 +10,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.UpcomingAppointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.HospitalWing;
@@ -201,6 +203,18 @@ public class ParserUtil {
             medicationSet.add(parseMedication(medicationName));
         }
         return medicationSet;
+    }
+
+    /**
+     * Parses {@code String upcomingAppointment} into a {@code UpcomingAppointment}.
+     */
+    public static UpcomingAppointment parseUpcomingAppointment(String upcomingAppointment) throws ParseException {
+        if (upcomingAppointment == null) {
+            return new UpcomingAppointment((LocalDate) null);
+        } else if (!UpcomingAppointment.isValidDate(upcomingAppointment)) {
+            throw new ParseException(UpcomingAppointment.MESSAGE_CONSTRAINTS);
+        }
+        return new UpcomingAppointment(upcomingAppointment);
     }
 }
 

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -1,0 +1,26 @@
+package seedu.address.model.appointment;
+
+import java.time.LocalDate;
+
+/**
+ * Represents an appointment for a patient.
+ */
+public abstract class Appointment {
+    private final LocalDate date;
+
+    /**
+     * Constructs an {@code Appointment} for a {@code Patient}.
+     * @param date of the appointment
+     */
+    public Appointment(LocalDate date) {
+        this.date = date;
+    }
+
+    /**
+     * Returns date of {@code Appointment}.
+     * @return the date of the appointment
+     */
+    public LocalDate getDate() {
+        return this.date;
+    }
+}

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -1,6 +1,8 @@
 package seedu.address.model.appointment;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Represents an appointment for a patient.

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -1,8 +1,6 @@
 package seedu.address.model.appointment;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 
 /**
  * Represents an appointment for a patient.

--- a/src/main/java/seedu/address/model/appointment/AppointmentType.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentType.java
@@ -1,0 +1,38 @@
+package seedu.address.model.appointment;
+
+import java.util.Locale;
+
+/**
+ * Describes the type of {@code Appointment}.
+ * Guarantee: Can only be P(ast) or U(pcoming).
+ */
+public enum AppointmentType {
+    PAST {
+        @Override
+        public String toString() {
+            return "P";
+        }
+    },
+    UPCOMING {
+        @Override
+        public String toString() {
+            return "U";
+        }
+    };
+
+    /**
+     * Returns an {@code AppointmentType} enum.
+     * @param strAppointmentType the string appointment type to be parsed
+     * @return the appointment type enum
+     */
+    public static AppointmentType parseAppointmentType(String strAppointmentType) {
+        String capsAppointmentType = strAppointmentType.toUpperCase(Locale.ROOT);
+        AppointmentType[] appointmentTypes = AppointmentType.values();
+        for (AppointmentType at : appointmentTypes) {
+            if (capsAppointmentType.equals(at.name()) || capsAppointmentType.equals(at.toString())) {
+                return at;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/model/appointment/PastAppointment.java
+++ b/src/main/java/seedu/address/model/appointment/PastAppointment.java
@@ -1,6 +1,7 @@
 package seedu.address.model.appointment;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 
 import seedu.address.model.tag.Medication;
@@ -44,7 +45,7 @@ public class PastAppointment extends Appointment {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append("On: ").append(getDate().toString());
+        builder.append("On: ").append(getDate().format(DateTimeFormatter.ofPattern("dd MMM yyyy")));
         builder.append("; Diagnosis: ").append(this.diagnosis);
         Set<Medication> tags = getMedication();
         if (!tags.isEmpty()) {

--- a/src/main/java/seedu/address/model/appointment/PastAppointment.java
+++ b/src/main/java/seedu/address/model/appointment/PastAppointment.java
@@ -10,18 +10,18 @@ import seedu.address.model.tag.Medication;
  * Guarantees: immutable as it is a sensitive record.
  */
 public class PastAppointment extends Appointment {
-    private final Set<Medication> prescription;
+    private final Set<Medication> medication;
     private final String diagnosis;
 
     /**
      * Constructs a {@code PastAppointment} for a {@code Patient}.
      * @param date of the appointment
-     * @param prescription the medications prescribed to the patient
+     * @param medication the medications prescribed to the patient
      * @param diagnosis the doctor's analysis of the patient's state
      */
-    public PastAppointment(LocalDate date, Set<Medication> prescription, String diagnosis) {
+    public PastAppointment(LocalDate date, Set<Medication> medication, String diagnosis) {
         super(date);
-        this.prescription = prescription;
+        this.medication = medication;
         this.diagnosis = diagnosis;
     }
 
@@ -29,8 +29,8 @@ public class PastAppointment extends Appointment {
      * Getter for the medications prescribed in the appointment.
      * @returns prescription for the patient
      */
-    public Set<Medication> getPrescription() {
-        return this.prescription;
+    public Set<Medication> getMedication() {
+        return this.medication;
     }
 
     /**
@@ -39,5 +39,18 @@ public class PastAppointment extends Appointment {
      */
     public String getDiagnosis() {
         return this.diagnosis;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("On: ").append(getDate().toString());
+        builder.append("; Diagnosis: ").append(this.diagnosis);
+        Set<Medication> tags = getMedication();
+        if (!tags.isEmpty()) {
+            builder.append("; Prescribed Medication: ");
+            tags.forEach(builder::append);
+        }
+        return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/model/appointment/PastAppointment.java
+++ b/src/main/java/seedu/address/model/appointment/PastAppointment.java
@@ -46,7 +46,7 @@ public class PastAppointment extends Appointment {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append("On: ").append(getDate().format(DateTimeFormatter.ofPattern("dd MMM yyyy")));
-        builder.append("; Diagnosis: ").append(this.diagnosis);
+        builder.append("; Diagnosis: ").append(getDiagnosis());
         Set<Medication> tags = getMedication();
         if (!tags.isEmpty()) {
             builder.append("; Prescribed Medication: ");

--- a/src/main/java/seedu/address/model/appointment/PastAppointment.java
+++ b/src/main/java/seedu/address/model/appointment/PastAppointment.java
@@ -1,0 +1,43 @@
+package seedu.address.model.appointment;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import seedu.address.model.tag.Medication;
+
+/**
+ * Represents a completed appointment for a patient.
+ * Guarantees: immutable as it is a sensitive record.
+ */
+public class PastAppointment extends Appointment {
+    private final Set<Medication> prescription;
+    private final String diagnosis;
+
+    /**
+     * Constructs a {@code PastAppointment} for a {@code Patient}.
+     * @param date of the appointment
+     * @param prescription the medications prescribed to the patient
+     * @param diagnosis the doctor's analysis of the patient's state
+     */
+    public PastAppointment(LocalDate date, Set<Medication> prescription, String diagnosis) {
+        super(date);
+        this.prescription = prescription;
+        this.diagnosis = diagnosis;
+    }
+
+    /**
+     * Getter for the medications prescribed in the appointment.
+     * @returns prescription for the patient
+     */
+    public Set<Medication> getPrescription() {
+        return this.prescription;
+    }
+
+    /**
+     * Getter for the doctor's diagnosis.
+     * @return diagnosis for the patient
+     */
+    public String getDiagnosis() {
+        return this.diagnosis;
+    }
+}

--- a/src/main/java/seedu/address/model/appointment/UpcomingAppointment.java
+++ b/src/main/java/seedu/address/model/appointment/UpcomingAppointment.java
@@ -1,16 +1,52 @@
 package seedu.address.model.appointment;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Represents an upcoming appointment for a patient.
  */
 public class UpcomingAppointment extends Appointment {
+    public static final String MESSAGE_CONSTRAINTS = "Date string should be of the format ddMMyy.";
+    public final String value;
     /**
      * Constructs an {@code UpcomingAppointment} for a {@code Patient}.
      * @param date of the appointment
      */
     public UpcomingAppointment(LocalDate date) {
         super(date);
+        if (date == null) {
+            this.value = null;
+        } else {
+            this.value = date.format(DateTimeFormatter.ofPattern("ddMMyy"));
+        }
+    }
+    /**
+     * Constructs an {@code UpcomingAppointment} for a {@code Patient}.
+     * @param dateString string representation of date of the appointment
+     */
+    public UpcomingAppointment(String dateString) {
+        super(LocalDate.parse(dateString, DateTimeFormatter.ofPattern("ddMMyy")));
+        this.value = dateString;
+    }
+
+    /**
+     * Returns true if a given string is a valid date.
+     */
+    public static boolean isValidDate(String test) {
+        if (test == null) {
+            return true;
+        }
+        try {
+            LocalDate.parse(test, DateTimeFormatter.ofPattern("ddMMyy"));
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public String toString() {
+        return "Upcoming Appointment Date: " + (value == null ? "None" : value);
     }
 }

--- a/src/main/java/seedu/address/model/appointment/UpcomingAppointment.java
+++ b/src/main/java/seedu/address/model/appointment/UpcomingAppointment.java
@@ -1,0 +1,16 @@
+package seedu.address.model.appointment;
+
+import java.time.LocalDate;
+
+/**
+ * Represents an upcoming appointment for a patient.
+ */
+public class UpcomingAppointment extends Appointment {
+    /**
+     * Constructs an {@code UpcomingAppointment} for a {@code Patient}.
+     * @param date of the appointment
+     */
+    public UpcomingAppointment(LocalDate date) {
+        super(date);
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,7 +2,6 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -38,8 +37,8 @@ public class Person {
      */
     public Person(Name name, Phone phone, Email email, NextOfKin nextOfKin, PatientType patientType,
                   HospitalWing hospitalWing, FloorNumber floorNumber,
-                  WardNumber wardNumber, Set<Medication> medications) {
-        requireAllNonNull(name, phone, email, nextOfKin, patientType, medications);
+                  WardNumber wardNumber, Set<Medication> medications, List<PastAppointment> pastAppointments) {
+        requireAllNonNull(name, phone, email, nextOfKin, patientType, medications, pastAppointments);
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -49,7 +48,7 @@ public class Person {
         this.floorNumber = Optional.ofNullable(floorNumber);
         this.wardNumber = Optional.ofNullable(wardNumber);
         this.medications.addAll(medications);
-        this.pastAppointments = new ArrayList<>();
+        this.pastAppointments = pastAppointments;
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.model.appointment.PastAppointment;
+import seedu.address.model.appointment.UpcomingAppointment;
 import seedu.address.model.tag.Medication;
 
 /**
@@ -31,14 +32,17 @@ public class Person {
     private final Optional<WardNumber> wardNumber;
     private final Set<Medication> medications = new HashSet<>();
     private final List<PastAppointment> pastAppointments;
+    private final Optional<UpcomingAppointment> upcomingAppointment;
 
     /**
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, NextOfKin nextOfKin, PatientType patientType,
-                  HospitalWing hospitalWing, FloorNumber floorNumber,
-                  WardNumber wardNumber, Set<Medication> medications, List<PastAppointment> pastAppointments) {
-        requireAllNonNull(name, phone, email, nextOfKin, patientType, medications, pastAppointments);
+                  HospitalWing hospitalWing, FloorNumber floorNumber, WardNumber wardNumber,
+                  Set<Medication> medications, List<PastAppointment> pastAppointments,
+                  UpcomingAppointment upcomingAppointment) {
+        requireAllNonNull(name, phone, email, nextOfKin, patientType, medications,
+                pastAppointments);
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -49,6 +53,7 @@ public class Person {
         this.wardNumber = Optional.ofNullable(wardNumber);
         this.medications.addAll(medications);
         this.pastAppointments = pastAppointments;
+        this.upcomingAppointment = Optional.ofNullable(upcomingAppointment);
     }
 
     public Name getName() {
@@ -158,6 +163,10 @@ public class Person {
         return pastAppointments;
     }
 
+    public Optional<UpcomingAppointment> getUpcomingAppointment() {
+        return upcomingAppointment;
+    }
+
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
@@ -194,6 +203,7 @@ public class Person {
             tags.forEach(builder::append);
         }
         builder.append("; Past Appointments: ").append(getPastAppointmentCount());
+        builder.append(" Upcoming Appointment: ").append(getUpcomingAppointment());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,12 +2,15 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import seedu.address.model.appointment.PastAppointment;
 import seedu.address.model.tag.Medication;
 
 /**
@@ -28,6 +31,7 @@ public class Person {
     private final Optional<FloorNumber> floorNumber;
     private final Optional<WardNumber> wardNumber;
     private final Set<Medication> medications = new HashSet<>();
+    private final List<PastAppointment> pastAppointments;
 
     /**
      * Every field must be present and not null.
@@ -45,6 +49,7 @@ public class Person {
         this.floorNumber = Optional.ofNullable(floorNumber);
         this.wardNumber = Optional.ofNullable(wardNumber);
         this.medications.addAll(medications);
+        this.pastAppointments = new ArrayList<>();
     }
 
     public Name getName() {
@@ -130,6 +135,30 @@ public class Person {
         return isEqual;
     }
 
+    /**
+     * Adds input {@code PastAppointment} to stored list of {@code PastAppointment}s.
+     * @param appt the {@code PastAppointment} to be added
+     */
+    public void addPastAppointment(PastAppointment appt) {
+        pastAppointments.add(appt);
+    }
+
+    /**
+     * Returns count of {@code PastAppointment}s to this patient.
+     * @return the count of {@code PastAppointment}s
+     */
+    public int getPastAppointmentCount() {
+        return pastAppointments.size();
+    }
+
+    /**
+     * Returns list of {@Code PastAppointment}s tagged to this patient.
+     * @return the list of {@code PastAppointment}s
+     */
+    public List<PastAppointment> getPastAppointments() {
+        return pastAppointments;
+    }
+
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
@@ -165,6 +194,7 @@ public class Person {
             builder.append("; Medications: ");
             tags.forEach(builder::append);
         }
+        builder.append("; Past Appointments: ").append(getPastAppointmentCount());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.appointment.PastAppointment;
+import seedu.address.model.appointment.UpcomingAppointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.HospitalWing;
@@ -31,24 +32,28 @@ public class SampleDataUtil {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                     new NextOfKin("Kwee Yeoh, Husband, 91912626"), new PatientType(PatientTypes.INPATIENT),
                     new HospitalWing("South"), new FloorNumber(10), new WardNumber(26),
-                    getMedicationSet("Paracetamol", "IV Drip"), new ArrayList<>()),
+                    getMedicationSet("Paracetamol", "IV Drip"), new ArrayList<>(),
+                    new UpcomingAppointment("120622")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                     new NextOfKin("Joe Yu, Husband, 82869128"), new PatientType(PatientTypes.OUTPATIENT),
-                    null, null, null, getMedicationSet(), new ArrayList<>()),
+                    null, null, null, getMedicationSet(), new ArrayList<>(),
+                    new UpcomingAppointment("120622")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                     new NextOfKin("Kenneth Oliverio, Son, 81249567"), new PatientType(PatientTypes.INPATIENT),
                     new HospitalWing("Wing 1"), new FloorNumber(1), new WardNumber(20),
-                    getMedicationSet(), new ArrayList<>()),
+                    getMedicationSet(), new ArrayList<>(), new UpcomingAppointment("120622")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                     new NextOfKin("Candince Yeo, Wife, 87598274"), new PatientType(PatientTypes.OUTPATIENT),
-                    null, null, null, getMedicationSet("Ibuprofen"), new ArrayList<>()),
+                    null, null, null, getMedicationSet("Ibuprofen"),
+                    new ArrayList<>(), new UpcomingAppointment("120622")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                     new NextOfKin("Mary Balakrishnan, Cousin, 87259826"), new PatientType(PatientTypes.OUTPATIENT),
-                    null, null, null, getMedicationSet("Anarax", "Canabeez"), new ArrayList<>()),
+                    null, null, null, getMedicationSet("Anarax", "Canabeez"),
+                    new ArrayList<>(), new UpcomingAppointment("120622")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                     new NextOfKin("Mary Balakrishnan, Wife, 87259826"), new PatientType(PatientTypes.INPATIENT),
                     new HospitalWing("South"), new FloorNumber(5), new WardNumber(29),
-                    getMedicationSet(), new ArrayList<>())
+                    getMedicationSet(), new ArrayList<>(), new UpcomingAppointment("120622"))
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,11 +1,15 @@
 package seedu.address.model.util;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.appointment.PastAppointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.HospitalWing;
@@ -27,22 +31,24 @@ public class SampleDataUtil {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                     new NextOfKin("Kwee Yeoh, Husband, 91912626"), new PatientType(PatientTypes.INPATIENT),
                     new HospitalWing("South"), new FloorNumber(10), new WardNumber(26),
-                    getMedicationSet("Paracetamol", "IV Drip")),
+                    getMedicationSet("Paracetamol", "IV Drip"), new ArrayList<>()),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                     new NextOfKin("Joe Yu, Husband, 82869128"), new PatientType(PatientTypes.OUTPATIENT),
-                    null, null, null, getMedicationSet()),
+                    null, null, null, getMedicationSet(), new ArrayList<>()),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                     new NextOfKin("Kenneth Oliverio, Son, 81249567"), new PatientType(PatientTypes.INPATIENT),
-                    new HospitalWing("Wing 1"), new FloorNumber(1), new WardNumber(20), getMedicationSet()),
+                    new HospitalWing("Wing 1"), new FloorNumber(1), new WardNumber(20),
+                    getMedicationSet(), new ArrayList<>()),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                     new NextOfKin("Candince Yeo, Wife, 87598274"), new PatientType(PatientTypes.OUTPATIENT),
-                    null, null, null, getMedicationSet("Ibuprofen")),
+                    null, null, null, getMedicationSet("Ibuprofen"), new ArrayList<>()),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                     new NextOfKin("Mary Balakrishnan, Cousin, 87259826"), new PatientType(PatientTypes.OUTPATIENT),
-                    null, null, null, getMedicationSet("Anarax", "Canabeez")),
+                    null, null, null, getMedicationSet("Anarax", "Canabeez"), new ArrayList<>()),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                     new NextOfKin("Mary Balakrishnan, Wife, 87259826"), new PatientType(PatientTypes.INPATIENT),
-                    new HospitalWing("South"), new FloorNumber(5), new WardNumber(29), getMedicationSet())
+                    new HospitalWing("South"), new FloorNumber(5), new WardNumber(29),
+                    getMedicationSet(), new ArrayList<>())
         };
     }
 
@@ -63,4 +69,11 @@ public class SampleDataUtil {
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * Returns a PastAppointment created from the data given.
+     */
+    public static PastAppointment getPastAppointment(String... strings) {
+        return new PastAppointment(LocalDate.parse(strings[0], DateTimeFormatter.ofPattern("ddMMyy")),
+                getMedicationSet(strings[1].split(" ")), strings[2]);
+    }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPastAppointment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPastAppointment.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.appointment.PastAppointment;
-import seedu.address.model.person.Person;
 import seedu.address.model.tag.Medication;
 
 /**
@@ -63,7 +62,8 @@ public class JsonAdaptedPastAppointment {
         if (pastAppointmentDate == null) {
             throw new IllegalValueException(String.format(APPT_MISSING_FIELD_MESSAGE_FORMAT, "date"));
         }
-        final LocalDate modelPastAppointmentDate = LocalDate.parse(pastAppointmentDate, DateTimeFormatter.ofPattern("ddMMyy"));
+        final LocalDate modelPastAppointmentDate = LocalDate.parse(pastAppointmentDate,
+                DateTimeFormatter.ofPattern("ddMMyy"));
         if (pastAppointmentMedication == null) {
             throw new IllegalValueException(String.format(APPT_MISSING_FIELD_MESSAGE_FORMAT,
                     Medication.class.getSimpleName()));

--- a/src/main/java/seedu/address/storage/JsonAdaptedPastAppointment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPastAppointment.java
@@ -1,0 +1,76 @@
+package seedu.address.storage;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.appointment.PastAppointment;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Medication;
+
+/**
+ * Jackson-friendly version of {@link PastAppointment}.
+ */
+public class JsonAdaptedPastAppointment {
+    public static final String APPT_MISSING_FIELD_MESSAGE_FORMAT = "PastAppointment's %s field is missing!";
+    private final String pastAppointmentDate;
+    private final String pastAppointmentDiagnosis;
+    private final List<JsonAdaptedMedication> pastAppointmentMedication = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedPastAppointment} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedPastAppointment(@JsonProperty("date") String date,
+                                      @JsonProperty("diagnosis") String diagnosis,
+                                      @JsonProperty("medication") List<JsonAdaptedMedication> medication) {
+        this.pastAppointmentDate = date;
+        this.pastAppointmentDiagnosis = diagnosis;
+        if (medication != null) {
+            this.pastAppointmentMedication.addAll(medication);
+        }
+    }
+
+    /**
+     * Converts a given {@code PastAppointment} into this class for Jackson use.
+     */
+    public JsonAdaptedPastAppointment(PastAppointment source) {
+        this.pastAppointmentDate = source.getDate().format(DateTimeFormatter.ofPattern("ddMMyy"));
+        this.pastAppointmentDiagnosis = source.getDiagnosis();
+        this.pastAppointmentMedication.addAll(source.getMedication().stream()
+                .map(JsonAdaptedMedication::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted person object into the model's {@code PastAppointment} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     */
+    public PastAppointment toModelType() throws IllegalValueException {
+        final List<Medication> personMedications = new ArrayList<>();
+        for (JsonAdaptedMedication medication : pastAppointmentMedication) {
+            personMedications.add(medication.toModelType());
+        }
+        if (pastAppointmentDate == null) {
+            throw new IllegalValueException(String.format(APPT_MISSING_FIELD_MESSAGE_FORMAT, "date"));
+        }
+        final LocalDate modelPastAppointmentDate = LocalDate.parse(pastAppointmentDate, DateTimeFormatter.ofPattern("ddMMyy"));
+        if (pastAppointmentMedication == null) {
+            throw new IllegalValueException(String.format(APPT_MISSING_FIELD_MESSAGE_FORMAT,
+                    Medication.class.getSimpleName()));
+        }
+        final Set<Medication> modelMedication = new HashSet<>(personMedications);
+        final String modelDiagnosis = pastAppointmentDiagnosis;
+
+        return new PastAppointment(modelPastAppointmentDate, modelMedication, modelDiagnosis);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -39,7 +39,7 @@ class JsonAdaptedPerson {
     private final String floorNumber;
     private final String wardNumber;
     private final List<JsonAdaptedMedication> medications = new ArrayList<>();
-    private final List<PastAppointment> pastAppointments = new ArrayList<>();
+    private final List<JsonAdaptedPastAppointment> pastAppointments = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -51,7 +51,8 @@ class JsonAdaptedPerson {
                              @JsonProperty("hospitalWing") String hospitalWing,
                              @JsonProperty("floorNumber") String floorNumber,
                              @JsonProperty("wardNumber") String wardNumber,
-                             @JsonProperty("medications") List<JsonAdaptedMedication> medications) {
+                             @JsonProperty("medications") List<JsonAdaptedMedication> medications,
+                             @JsonProperty("pastAppointments") List<JsonAdaptedPastAppointment> pastAppointments) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -62,6 +63,9 @@ class JsonAdaptedPerson {
         this.wardNumber = wardNumber;
         if (medications != null) {
             this.medications.addAll(medications);
+        }
+        if (pastAppointments != null) {
+            this.pastAppointments.addAll(pastAppointments);
         }
     }
 
@@ -92,6 +96,9 @@ class JsonAdaptedPerson {
         medications.addAll(source.getMedications().stream()
                 .map(JsonAdaptedMedication::new)
                 .collect(Collectors.toList()));
+        pastAppointments.addAll(source.getPastAppointments().stream()
+                .map(JsonAdaptedPastAppointment::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -103,6 +110,10 @@ class JsonAdaptedPerson {
         final List<Medication> personMedications = new ArrayList<>();
         for (JsonAdaptedMedication medication : medications) {
             personMedications.add(medication.toModelType());
+        }
+        final List<PastAppointment> personPastAppointments = new ArrayList<>();
+        for (JsonAdaptedPastAppointment pastAppointment : pastAppointments) {
+            personPastAppointments.add(pastAppointment.toModelType());
         }
 
         if (name == null) {
@@ -204,9 +215,9 @@ class JsonAdaptedPerson {
         final WardNumber modelWardNumber = wardNumber == null ? null : new WardNumber(wN);
 
         final Set<Medication> modelMedication = new HashSet<>(personMedications);
+        final List<PastAppointment> modelPastAppointments = new ArrayList<>(personPastAppointments);
 
         return new Person(modelName, modelPhone, modelEmail, modelNextOfKin, modelPatientType,
-                modelHospitalWing, modelFloorNumber, modelWardNumber, modelMedication);
+                modelHospitalWing, modelFloorNumber, modelWardNumber, modelMedication, modelPastAppointments);
     }
-
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.appointment.PastAppointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.HospitalWing;
@@ -38,6 +39,7 @@ class JsonAdaptedPerson {
     private final String floorNumber;
     private final String wardNumber;
     private final List<JsonAdaptedMedication> medications = new ArrayList<>();
+    private final List<PastAppointment> pastAppointments = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -50,6 +50,8 @@ public class PersonCard extends UiPart<Region> {
     private FlowPane medications;
     @FXML
     private Label appointments;
+    @FXML
+    private Label upcomingAppointment;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -73,6 +75,8 @@ public class PersonCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(medication -> medication.medicationName))
                 .forEach(medication -> medications.getChildren().add(new Label(medication.medicationName + " ")));
         appointments.setText("Past Appointments: " + person.getPastAppointmentCount());
+        person.getUpcomingAppointment().ifPresentOrElse(ua -> upcomingAppointment.setText(ua.toString()), () ->
+                upcomingAppointment.setVisible(false));
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -48,6 +48,8 @@ public class PersonCard extends UiPart<Region> {
     private Label wardNumber;
     @FXML
     private FlowPane medications;
+    @FXML
+    private Label appointments;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -69,7 +71,8 @@ public class PersonCard extends UiPart<Region> {
                 wardNumber.setVisible(false));
         person.getMedications().stream()
                 .sorted(Comparator.comparing(medication -> medication.medicationName))
-                .forEach(medication -> medications.getChildren().add(new Label(medication.medicationName)));
+                .forEach(medication -> medications.getChildren().add(new Label(medication.medicationName + " ")));
+        appointments.setText("Past Appointments: " + person.getPastAppointmentCount());
     }
 
     @Override

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,10 +31,11 @@
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="nextOfKin" styleClass="cell_small_label" text="\$nextOfKin" />
       <Label fx:id="patientType" styleClass="cell_small_label" text="\$patientType" />
+      <Label fx:id="appointments" styleClass="cell_small_label" text="\$appointments" />
+      <FlowPane fx:id="medications" />
       <Label fx:id="hospitalWing" styleClass="cell_small_label" text="\$hospitalWing" />
       <Label fx:id="floorNumber" styleClass="cell_small_label" text="\$floorNumber" />
       <Label fx:id="wardNumber" styleClass="cell_small_label" text="\$wardNumber" />
-      <FlowPane fx:id="medications" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -32,6 +32,7 @@
       <Label fx:id="nextOfKin" styleClass="cell_small_label" text="\$nextOfKin" />
       <Label fx:id="patientType" styleClass="cell_small_label" text="\$patientType" />
       <Label fx:id="appointments" styleClass="cell_small_label" text="\$appointments" />
+      <Label fx:id="upcomingAppointment" styleClass="cell_small_label" text="\$upcomingAppointment" />
       <FlowPane fx:id="medications" />
       <Label fx:id="hospitalWing" styleClass="cell_small_label" text="\$hospitalWing" />
       <Label fx:id="floorNumber" styleClass="cell_small_label" text="\$floorNumber" />

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -28,6 +28,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_WARD_NUMBER = "bense";
     private static final String INVALID_MEDICATION = " ";
     private static final String[] INVALID_PAST_APPOINTMENT = {".", ".", "."};
+    private static final String INVALID_UPCOMING_APPOINTMENT = "12345678";
 
     private static final String VALID_NAME = BENSON.getName().fullName;
     private static final String VALID_PHONE = BENSON.getPhone().value;
@@ -43,6 +44,7 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedPastAppointment> VALID_PAST_APPOINTMENTS = BENSON.getPastAppointments()
             .stream().map(JsonAdaptedPastAppointment::new)
             .collect(Collectors.toList());
+    private static final String VALID_UPCOMING_APPOINTMENT = BENSON.getUpcomingAppointment().get().value;
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -55,7 +57,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
                         VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
-                        VALID_PAST_APPOINTMENTS);
+                        VALID_PAST_APPOINTMENTS, VALID_UPCOMING_APPOINTMENT);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -64,7 +66,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN,
                 VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
-                VALID_PAST_APPOINTMENTS);
+                VALID_PAST_APPOINTMENTS, VALID_UPCOMING_APPOINTMENT);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -74,7 +76,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
                         VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
-                        VALID_PAST_APPOINTMENTS);
+                        VALID_PAST_APPOINTMENTS, VALID_UPCOMING_APPOINTMENT);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -83,7 +85,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_NEXT_OF_KIN,
                 VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
-                VALID_PAST_APPOINTMENTS);
+                VALID_PAST_APPOINTMENTS, VALID_UPCOMING_APPOINTMENT);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -93,7 +95,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
                         VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
-                        VALID_PAST_APPOINTMENTS);
+                        VALID_PAST_APPOINTMENTS, VALID_UPCOMING_APPOINTMENT);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -102,7 +104,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_NEXT_OF_KIN,
                 VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
-                VALID_PAST_APPOINTMENTS);
+                VALID_PAST_APPOINTMENTS, VALID_UPCOMING_APPOINTMENT);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -112,7 +114,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
                         VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
-                        VALID_PAST_APPOINTMENTS);
+                        VALID_PAST_APPOINTMENTS, VALID_UPCOMING_APPOINTMENT);
         String expectedMessage = NextOfKin.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -121,7 +123,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullNextOfKin_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
                 VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
-                VALID_PAST_APPOINTMENTS);
+                VALID_PAST_APPOINTMENTS, VALID_UPCOMING_APPOINTMENT);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, NextOfKin.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -133,19 +135,28 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
                         VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, invalidMedications,
-                        VALID_PAST_APPOINTMENTS);
+                        VALID_PAST_APPOINTMENTS, VALID_UPCOMING_APPOINTMENT);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidPastAppointments_throwsIllegalValueException() {
-        List<JsonAdaptedMedication> invalidMedications = new ArrayList<>(VALID_MEDICATIONS);
-        invalidMedications.add(new JsonAdaptedMedication(INVALID_MEDICATION));
+        List<JsonAdaptedMedication> validMedications = new ArrayList<>(VALID_MEDICATIONS);
         List<JsonAdaptedPastAppointment> invalidPastAppointments = new ArrayList<>(VALID_PAST_APPOINTMENTS);
-        invalidPastAppointments.add(new JsonAdaptedPastAppointment("", "", invalidMedications));
+        invalidPastAppointments.add(new JsonAdaptedPastAppointment("", "", validMedications));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
                         VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
-                        invalidPastAppointments);
+                        invalidPastAppointments, VALID_UPCOMING_APPOINTMENT);
+        assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidUpcomingAppointment_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                        VALID_PAST_APPOINTMENTS, INVALID_UPCOMING_APPOINTMENT);
+        assertThrows(IllegalValueException.class, person::toModelType);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import seedu.address.model.appointment.PastAppointment;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -27,6 +28,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_FLOOR_NUMBER = "-1";
     private static final String INVALID_WARD_NUMBER = "bense";
     private static final String INVALID_MEDICATION = " ";
+    private static final String[] INVALID_PAST_APPOINTMENT = {".", ".", "."};
 
     private static final String VALID_NAME = BENSON.getName().fullName;
     private static final String VALID_PHONE = BENSON.getPhone().value;
@@ -39,6 +41,9 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedMedication> VALID_MEDICATIONS = BENSON.getMedications().stream()
             .map(JsonAdaptedMedication::new)
             .collect(Collectors.toList());
+    private static final List<JsonAdaptedPastAppointment> VALID_PAST_APPOINTMENTS = BENSON.getPastAppointments()
+            .stream().map(JsonAdaptedPastAppointment::new)
+            .collect(Collectors.toList());
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -50,7 +55,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -58,7 +63,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN,
-                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS);
+                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -67,7 +72,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -75,7 +80,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_NEXT_OF_KIN,
-                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS);
+                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -84,7 +89,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -92,7 +97,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_NEXT_OF_KIN,
-                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS);
+                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -101,7 +106,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidNextOfKin_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
         String expectedMessage = NextOfKin.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -109,7 +114,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullNextOfKin_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS);
+                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, NextOfKin.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -120,8 +125,18 @@ public class JsonAdaptedPersonTest {
         invalidMedications.add(new JsonAdaptedMedication(INVALID_MEDICATION));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, invalidMedications);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, invalidMedications, VALID_PAST_APPOINTMENTS);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
+    @Test
+    public void toModelType_invalidPastAppointments_throwsIllegalValueException() {
+        List<JsonAdaptedMedication> invalidMedications = new ArrayList<>(VALID_MEDICATIONS);
+        invalidMedications.add(new JsonAdaptedMedication(INVALID_MEDICATION));
+        List<JsonAdaptedPastAppointment> invalidPastAppointments = new ArrayList<>(VALID_PAST_APPOINTMENTS);
+        invalidPastAppointments.add(new JsonAdaptedPastAppointment("", "", invalidMedications));
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, invalidPastAppointments);
+    }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,7 +1,6 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import seedu.address.model.appointment.PastAppointment;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -55,7 +54,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                        VALID_PAST_APPOINTMENTS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -63,7 +63,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN,
-                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
+                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                VALID_PAST_APPOINTMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -72,7 +73,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                        VALID_PAST_APPOINTMENTS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -80,7 +82,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_NEXT_OF_KIN,
-                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
+                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                VALID_PAST_APPOINTMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -89,7 +92,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                        VALID_PAST_APPOINTMENTS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -97,7 +101,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_NEXT_OF_KIN,
-                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
+                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                VALID_PAST_APPOINTMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -106,7 +111,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidNextOfKin_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                        VALID_PAST_APPOINTMENTS);
         String expectedMessage = NextOfKin.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -114,7 +120,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullNextOfKin_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, VALID_PAST_APPOINTMENTS);
+                VALID_PATIENT_TYPE, VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                VALID_PAST_APPOINTMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, NextOfKin.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -125,7 +132,8 @@ public class JsonAdaptedPersonTest {
         invalidMedications.add(new JsonAdaptedMedication(INVALID_MEDICATION));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, invalidMedications, VALID_PAST_APPOINTMENTS);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, invalidMedications,
+                        VALID_PAST_APPOINTMENTS);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
@@ -137,6 +145,7 @@ public class JsonAdaptedPersonTest {
         invalidPastAppointments.add(new JsonAdaptedPastAppointment("", "", invalidMedications));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
-                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS, invalidPastAppointments);
+                        VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
+                        invalidPastAppointments);
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -167,6 +167,10 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Parses the {@code appointmentData} into a {@code PastAppointment}
+     * and sets it to the {@code Persn} that we are building.
+     */
     public PersonBuilder withPastAppointment(String ... appointmentData) {
         this.pastAppointments.add(SampleDataUtil.getPastAppointment(appointmentData));
         return this;

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,11 +1,14 @@
 package seedu.address.testutil;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import seedu.address.model.appointment.PastAppointment;
+import seedu.address.model.appointment.UpcomingAppointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.HospitalWing;
@@ -32,6 +35,7 @@ public class PersonBuilder {
     public static final String DEFAULT_HOSPITAL_WING = "south";
     public static final Integer DEFAULT_FLOOR_NUMBER = 3;
     public static final Integer DEFAULT_WARD_NUMBER = 69;
+    public static final String DEFAULT_UPCOMING_APPOINTMENT = "120622";
 
     private Name name;
     private Phone phone;
@@ -43,6 +47,7 @@ public class PersonBuilder {
     private WardNumber wardNumber;
     private Set<Medication> medications;
     private List<PastAppointment> pastAppointments;
+    private UpcomingAppointment upcomingAppointment;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -58,6 +63,7 @@ public class PersonBuilder {
         wardNumber = new WardNumber(DEFAULT_WARD_NUMBER);
         medications = new HashSet<>();
         pastAppointments = new ArrayList<>();
+        upcomingAppointment = new UpcomingAppointment(DEFAULT_UPCOMING_APPOINTMENT);
     }
 
     /**
@@ -74,6 +80,7 @@ public class PersonBuilder {
         wardNumber = personToCopy.getWardNumber().orElse(null);
         medications = new HashSet<>(personToCopy.getMedications());
         pastAppointments = personToCopy.getPastAppointments();
+        upcomingAppointment = personToCopy.getUpcomingAppointment().orElse(null);
     }
 
     /**
@@ -169,10 +176,24 @@ public class PersonBuilder {
 
     /**
      * Parses the {@code appointmentData} into a {@code PastAppointment}
-     * and sets it to the {@code Persn} that we are building.
+     * and sets it to the {@code Person} that we are building.
      */
     public PersonBuilder withPastAppointment(String ... appointmentData) {
         this.pastAppointments.add(SampleDataUtil.getPastAppointment(appointmentData));
+        return this;
+    }
+
+    /**
+     * Parses the {@code dateString} into a {@code UpcomingAppointment}
+     * and sets it to the {@code Person} that we are building.
+     */
+    public PersonBuilder withUpcomingAppointment(String dateString) {
+        if (dateString == null) {
+            this.upcomingAppointment = new UpcomingAppointment((LocalDate) null);
+        } else {
+            this.upcomingAppointment =
+                    new UpcomingAppointment(LocalDate.parse(dateString, DateTimeFormatter.ofPattern("ddMMyy")));
+        }
         return this;
     }
 
@@ -181,7 +202,7 @@ public class PersonBuilder {
      */
     public Person build() {
         return new Person(name, phone, email, nextOfKin, patientType, hospitalWing,
-                floorNumber, wardNumber, medications, pastAppointments);
+                floorNumber, wardNumber, medications, pastAppointments, upcomingAppointment);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,8 +1,11 @@
 package seedu.address.testutil;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import seedu.address.model.appointment.PastAppointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FloorNumber;
 import seedu.address.model.person.HospitalWing;
@@ -39,6 +42,7 @@ public class PersonBuilder {
     private FloorNumber floorNumber;
     private WardNumber wardNumber;
     private Set<Medication> medications;
+    private List<PastAppointment> pastAppointments;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -53,6 +57,7 @@ public class PersonBuilder {
         floorNumber = new FloorNumber(DEFAULT_FLOOR_NUMBER);
         wardNumber = new WardNumber(DEFAULT_WARD_NUMBER);
         medications = new HashSet<>();
+        pastAppointments = new ArrayList<>();
     }
 
     /**
@@ -68,6 +73,7 @@ public class PersonBuilder {
         floorNumber = personToCopy.getFloorNumber().orElse(null);
         wardNumber = personToCopy.getWardNumber().orElse(null);
         medications = new HashSet<>(personToCopy.getMedications());
+        pastAppointments = personToCopy.getPastAppointments();
     }
 
     /**
@@ -161,12 +167,17 @@ public class PersonBuilder {
         return this;
     }
 
+    public PersonBuilder withPastAppointment(String ... appointmentData) {
+        this.pastAppointments.add(SampleDataUtil.getPastAppointment(appointmentData));
+        return this;
+    }
+
     /**
      * Builds the Person.
      */
     public Person build() {
         return new Person(name, phone, email, nextOfKin, patientType, hospitalWing,
-                floorNumber, wardNumber, medications);
+                floorNumber, wardNumber, medications, pastAppointments);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -34,7 +34,8 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier").withPhone("98765432")
             .withEmail("johnd@example.com").withNextOfKin("Daniel Meier, Husband, 81273546")
             .withPatientType(PatientTypes.INPATIENT).withHospitalWing("south").withFloorNumber(1).withWardNumber(26)
-            .withMedication("Paracetamol", "Xanax").build();
+            .withMedication("Paracetamol", "Xanax").withPastAppointment("120622", "Paracetamol Ibuprofen", "Sick")
+            .withPastAppointment("140622", "Chlormine Amoxycillin", "Sick").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withNextOfKin("Charlie Pauline, Brother, 81273645")
             .withPatientType(PatientTypes.OUTPATIENT).build();

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -35,7 +35,7 @@ public class TypicalPersons {
             .withEmail("johnd@example.com").withNextOfKin("Daniel Meier, Husband, 81273546")
             .withPatientType(PatientTypes.INPATIENT).withHospitalWing("south").withFloorNumber(1).withWardNumber(26)
             .withMedication("Paracetamol", "Xanax").withPastAppointment("120622", "Paracetamol Ibuprofen", "Sick")
-            .withPastAppointment("140622", "Chlormine Amoxycillin", "Sick").build();
+            .withPastAppointment("140622", "Chlormine Amoxycillin", "Sick").withUpcomingAppointment("120622").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withNextOfKin("Charlie Pauline, Brother, 81273645")
             .withPatientType(PatientTypes.OUTPATIENT).build();


### PR DESCRIPTION
Right now, patients have a medication field attached to them. There is no proper use of this field, and we should aim to replace it with "Upcoming Appointment" and "Past Appointment" fields. For this to be possible, we need to create the relevent Appointment classes.

As such, the following changes are recommended:
- Create abstract Appointment class with date field
- Create enum to differentiate between types of appointments
- Create PastAppointment and UpcomingAppointment classes
  - PastAppointment contains additional medication and diagnosis fields
- Add parsing instructions for PastAppointments

Todo:
- [x] Attach PastAppointments to Person
- [x] Update UI to display past appointments' count
- [x] Implement UpcomingAppointment
- [x] Attach UpcomingAppointment to Person
- [x] Update UI to display upcoming appointment date