### PR TITLE
Implement get /n feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/GetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GetCommand.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.commands.getcommands.GetFloorNumberCommand.FLOOR_NUMBER_PREFIX;
 import static seedu.address.logic.commands.getcommands.GetHospitalWingCommand.HOSPITAL_WING_PREFIX;
 import static seedu.address.logic.commands.getcommands.GetInpatientCommand.INPATIENT_PREFIX;
+import static seedu.address.logic.commands.getcommands.GetNameCommand.NAME_PREFIX;
 import static seedu.address.logic.commands.getcommands.GetOutpatientCommand.OUTPATIENT_PREFIX;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -22,12 +23,14 @@ public class GetCommand extends Command {
             + OUTPATIENT_PREFIX + ", "
             + INPATIENT_PREFIX + ", "
             + FLOOR_NUMBER_PREFIX + " FLOOR NUMBER, "
-            + HOSPITAL_WING_PREFIX + " HOSPITAL WING\n"
+            + HOSPITAL_WING_PREFIX + " HOSPITAL WING, "
+            + NAME_PREFIX + " NAME\n"
             + "Examples: "
             + COMMAND_WORD + " " + OUTPATIENT_PREFIX + ", "
             + COMMAND_WORD + " " + INPATIENT_PREFIX + ", "
             + COMMAND_WORD + " " + FLOOR_NUMBER_PREFIX + " 3 5 9, "
-            + COMMAND_WORD + " " + HOSPITAL_WING_PREFIX + " south";
+            + COMMAND_WORD + " " + HOSPITAL_WING_PREFIX + " south"
+            + COMMAND_WORD + " " + NAME_PREFIX + " alice bob charlie";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/getcommands/GetNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/getcommands/GetNameCommand.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.commands.getcommands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.GetCommand;
+import seedu.address.model.Model;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+import static java.util.Objects.requireNonNull;
+
+public class GetNameCommand extends GetCommand {
+
+    public static final String NAME_PREFIX = "/n";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Gets all persons whose names contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: "
+            + NAME_PREFIX + " NAME\n"
+            + "Example: "
+            + COMMAND_WORD + " "
+            + NAME_PREFIX
+            + " alice bob charlie";
+
+    private final NameContainsKeywordsPredicate predicate;
+
+    public GetNameCommand(NameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof GetNameCommand // instanceof handles nulls
+                && predicate.equals(((GetNameCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/getcommands/GetNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/getcommands/GetNameCommand.java
@@ -1,14 +1,17 @@
 package seedu.address.logic.commands.getcommands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.GetCommand;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
-import static java.util.Objects.requireNonNull;
-
+/**
+ * Finds and lists all persons in checkUp whose name contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
 public class GetNameCommand extends GetCommand {
 
     public static final String NAME_PREFIX = "/n";

--- a/src/main/java/seedu/address/logic/parser/GetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GetCommandParser.java
@@ -10,10 +10,12 @@ import seedu.address.logic.commands.GetCommand;
 import seedu.address.logic.commands.getcommands.GetFloorNumberCommand;
 import seedu.address.logic.commands.getcommands.GetHospitalWingCommand;
 import seedu.address.logic.commands.getcommands.GetInpatientCommand;
+import seedu.address.logic.commands.getcommands.GetNameCommand;
 import seedu.address.logic.commands.getcommands.GetOutpatientCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.logic.parser.getparsers.GetFloorNumberParser;
+import seedu.address.logic.parser.getparsers.GetFloorNumberCommandParser;
 import seedu.address.logic.parser.getparsers.GetHospitalWingCommandParser;
+import seedu.address.logic.parser.getparsers.GetNameCommandParser;
 
 /**
  * Parses get command input
@@ -39,10 +41,13 @@ public class GetCommandParser implements Parser<GetCommand> {
                 return new GetInpatientCommand();
 
             case GetFloorNumberCommand.FLOOR_NUMBER_PREFIX:
-                return new GetFloorNumberParser().parse(arguments);
+                return new GetFloorNumberCommandParser().parse(arguments);
 
             case GetHospitalWingCommand.HOSPITAL_WING_PREFIX:
                 return new GetHospitalWingCommandParser().parse(arguments);
+
+            case GetNameCommand.NAME_PREFIX:
+                return new GetNameCommandParser().parse(arguments);
 
             default:
                 throw new ParseException(String.format(MESSAGE_INVALID_GET_PREFIX,

--- a/src/main/java/seedu/address/logic/parser/getparsers/GetFloorNumberCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/getparsers/GetFloorNumberCommandParser.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.FloorNumberContainsKeywordsPredicate;
 /**
  * Parses input arguments and creates a new GetFloorNumberCommand object
  */
-public class GetFloorNumberParser implements Parser<GetFloorNumberCommand> {
+public class GetFloorNumberCommandParser implements Parser<GetFloorNumberCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the GetFloorNumberCommand

--- a/src/main/java/seedu/address/logic/parser/getparsers/GetNameCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/getparsers/GetNameCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser.getparsers;
+
+import seedu.address.logic.commands.getcommands.GetNameCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+public class GetNameCommandParser implements Parser<GetNameCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the GetNameCommand
+     * and returns a GetNameCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public GetNameCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, GetNameCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new GetNameCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/getparsers/GetNameCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/getparsers/GetNameCommandParser.java
@@ -1,14 +1,17 @@
 package seedu.address.logic.parser.getparsers;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
 import seedu.address.logic.commands.getcommands.GetNameCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
-import java.util.Arrays;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
+/**
+ * Parses input arguments and creates a new GetNameCommand object
+ */
 public class GetNameCommandParser implements Parser<GetNameCommand> {
 
     /**


### PR DESCRIPTION
Quick fix for parking original `find` command in AB3 into a `get /n` command, as our implementation for get is essentially a filter. Future iterations might remove the AB3 implementation of `find` command.

Close #1.