### PR TITLE
Implement get/nok feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/getcommands/GetNextOfKinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/getcommands/GetNextOfKinCommand.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.commands.getcommands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GetCommand;
+import seedu.address.model.Model;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NextOfKinPredicate;
+
+/**
+ * Finds the next-of-kin data of the given patient.
+ * Keyword matching is case insensitive.
+ */
+public class GetNextOfKinCommand extends GetCommand {
+
+    public static final String NEXT_OF_KIN_PREFIX = "/nok";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds the next-of-kin data with the given  "
+            + "specified keywords (patient name; case insensitive) \n"
+            + "Parameters: "
+            + NEXT_OF_KIN_PREFIX + " PATIENT NAME\n"
+            + "Example: "
+            + COMMAND_WORD + " "
+            + NEXT_OF_KIN_PREFIX
+            + " alice ";
+
+    private final NextOfKinPredicate predicate;
+
+    public GetNextOfKinCommand(NextOfKinPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof GetNextOfKinCommand // instanceof handles nulls
+                && predicate.equals(((GetNextOfKinCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/getcommands/GetNextOfKinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/getcommands/GetNextOfKinCommand.java
@@ -6,7 +6,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.GetCommand;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.NextOfKinPredicate;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/GetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GetCommandParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.getcommands.GetFloorNumberCommand;
 import seedu.address.logic.commands.getcommands.GetHospitalWingCommand;
 import seedu.address.logic.commands.getcommands.GetInpatientCommand;
 import seedu.address.logic.commands.getcommands.GetNameCommand;
+import seedu.address.logic.commands.getcommands.GetNextOfKinCommand;
 import seedu.address.logic.commands.getcommands.GetOutpatientCommand;
 import seedu.address.logic.commands.getcommands.GetWardNumberCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -18,6 +19,7 @@ import seedu.address.logic.parser.getparsers.GetFloorNumberCommandParser;
 import seedu.address.logic.parser.getparsers.GetHospitalWingCommandParser;
 import seedu.address.logic.parser.getparsers.GetNameCommandParser;
 import seedu.address.logic.parser.getparsers.GetWardNumberCommandParser;
+import seedu.address.logic.parser.getparsers.GetNextOfKinCommandParser;
 
 /**
  * Parses get command input
@@ -53,6 +55,9 @@ public class GetCommandParser implements Parser<GetCommand> {
 
             case GetNameCommand.NAME_PREFIX:
                 return new GetNameCommandParser().parse(arguments);
+
+            case GetNextOfKinCommand.NEXT_OF_KIN_PREFIX:
+                return new GetNextOfKinCommandParser().parse(arguments);
 
             default:
                 throw new ParseException(String.format(MESSAGE_INVALID_GET_PREFIX,

--- a/src/main/java/seedu/address/logic/parser/GetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GetCommandParser.java
@@ -18,8 +18,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.getparsers.GetFloorNumberCommandParser;
 import seedu.address.logic.parser.getparsers.GetHospitalWingCommandParser;
 import seedu.address.logic.parser.getparsers.GetNameCommandParser;
-import seedu.address.logic.parser.getparsers.GetWardNumberCommandParser;
 import seedu.address.logic.parser.getparsers.GetNextOfKinCommandParser;
+import seedu.address.logic.parser.getparsers.GetWardNumberCommandParser;
 
 /**
  * Parses get command input

--- a/src/main/java/seedu/address/logic/parser/getparsers/GetNextOfKinCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/getparsers/GetNextOfKinCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser.getparsers;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.getcommands.GetNextOfKinCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NextOfKinPredicate;
+
+/**
+ * Parses input arguments and creates a new GetNextOfKinCommand object
+ */
+public class GetNextOfKinCommandParser implements Parser<GetNextOfKinCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the GetNextOfKinCommand
+     * and returns a GetNextOfKinCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public GetNextOfKinCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, GetNextOfKinCommand.MESSAGE_USAGE));
+        }
+
+        String[] nextOfKinKeywords = trimmedArgs.split("\\s+");
+
+        return new GetNextOfKinCommand(new NextOfKinPredicate(Arrays.asList(nextOfKinKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/NextOfKinPredicate.java
+++ b/src/main/java/seedu/address/model/person/NextOfKinPredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Next Of Kin Data} matches any of the keywords given.
+ */
+public class NextOfKinPredicate implements Predicate<Person> {
+    private final List<String> patientName;
+
+    public NextOfKinPredicate(List<String> patientName) {
+        this.patientName = patientName;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return patientName.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof NextOfKinPredicate// instanceof handles nulls
+                && patientName.equals(((NextOfKinPredicate) other).patientName)); // state check
+    }
+}


### PR DESCRIPTION
whereby we can retrieve a patient's next-of-kin data

Format `get /nok [PATIENT'S NAME]`

Things to improve for v1.3:
Hide all the other irrelevant fields (e.g., email address, etc) in the Person Card while `get /nok` is called.