### PR TITLE
Enable assertions, rename .jar filename

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,11 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'checkUp.jar'
 }
 
 defaultTasks 'clean', 'test'
+
+run {
+    enableAssertions = true
+}


### PR DESCRIPTION
- Assertions enabled in `build.gradle`
- shadowJar now creates `checkUp.jar` instead of `addressbook.jar`

Closes #74 