### PR TITLE
Add more testing and restrictions to patient's fields

### DIFF
--- a/docs/team/peiyee88.md
+++ b/docs/team/peiyee88.md
@@ -2,7 +2,58 @@
 layout: page
 title: Pei Yee's Project Portfolio Page
 ---
+# Project: checkUp
 
-### Project: AddressBook Level 3
+## Overview
 
-Below are my contributions:
+checkUp is a desktop address book application used for managing patients' details efficiently. 
+The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+
+Given below are my contributions to the project.
+
+## Summary of Contributions
+
+### Code contributed
+RepoSense: [link](https://nus-cs2103-ay2223s1.github.io/tp-dashboard/?search=peiyee88&breakdown=true)
+
+### Enhancements implemented
+
+- Retrieve patient's next-of-kin data: `get /nok`
+    - What it does: Returns that particular patient's next-of-kin data.
+    - Justification: Allows medical staff to easily contact the patient's next-of-kin when needed.
+- Retrieve a list of patients within a hospital wing: `get /hw`
+    - What it does: Returns all the patients details staying within a hospital wing.
+    - Justification: Allow medical staff to easily know that whether a particular hospital wing is oversubscribed.
+    - Also, it allows nurses to attend to the patients faster.
+- Retrieve a list of appointments by date: `get /appton`
+    - What it does: Returns a list of patients that has appointment scheduled on the particular date.
+    - Justification: Allows medical staff to keep track of all the appointments.
+
+### Contributions to the UG
+
+- Create skeletal version of user guide.
+- Added user documentation for `get /nok`, 
+- Added user documentation for `get /appton`
+- Added user documentation for `get /hw`
+- Updated command summary.
+
+### Contributions to the DG
+
+- Added documentation for the following features `get /nok` `get /hw` `get /appton` which includ:
+    - A description of the feature.
+    - Class and object diagrams for the feature's implementation. [TBA]
+    - A possible use case with outlined steps for the feature. [TBA]
+    - A sequence diagram of the use case with method calls shown. 
+
+### Contributions to team-based tasks
+
+- Create skeletal version of documentation.
+- Updated CI status and CodeCov badges in `index.md`.
+- Managed milestones `v1.1`, `v1.2`, `v1.2b`, `v1.3` progress in the team.
+- Ensured team was on schedule with frequent reminders on deadlines and pending tasks.
+
+### Review/mentoring contributions
+
+- Reviewed multiple PRs across the different SDLC versions.
+
+### Contributions beyond the project team

--- a/src/main/java/seedu/address/logic/parser/getparsers/GetHospitalWingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/getparsers/GetHospitalWingCommandParser.java
@@ -2,7 +2,8 @@ package seedu.address.logic.parser.getparsers;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import seedu.address.logic.commands.getcommands.GetHospitalWingCommand;
 import seedu.address.logic.parser.Parser;
@@ -26,9 +27,10 @@ public class GetHospitalWingCommandParser implements Parser<GetHospitalWingComma
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, GetHospitalWingCommand.MESSAGE_USAGE));
         }
 
-        String[] hospitalWings = trimmedArgs.split("\\s+");
+        List<String> hospitalWings = new ArrayList<String>();
+        hospitalWings.add(trimmedArgs);
 
-        return new GetHospitalWingCommand(new HospitalWingContainsKeywordsPredicate(Arrays.asList(hospitalWings)));
+        return new GetHospitalWingCommand(new HospitalWingContainsKeywordsPredicate(hospitalWings));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/AppointmentByDatePredicate.java
+++ b/src/main/java/seedu/address/model/person/AppointmentByDatePredicate.java
@@ -43,13 +43,11 @@ public class AppointmentByDatePredicate implements Predicate<Person> {
     }
 
     private boolean isPresentUpcomingAppointment(Person person) {
-        return !appointments.stream().anyMatch(keyword
-                -> person.getUpcomingAppointment().get().value == null);
+        return person.getUpcomingAppointment().get().value != null;
     }
 
     private boolean isPresentPastAppointment(Person person) {
-        return appointments.stream().anyMatch(keyword
-                -> person.getPastAppointments().size() != 0);
+        return person.getPastAppointments().size() != 0;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/AppointmentByDatePredicate.java
+++ b/src/main/java/seedu/address/model/person/AppointmentByDatePredicate.java
@@ -25,18 +25,31 @@ public class AppointmentByDatePredicate implements Predicate<Person> {
      */
     @Override
     public boolean test(Person person) {
-        Boolean hasMatchPastAppointments = appointments.stream().anyMatch(
-                keyword -> person.getPastAppointments().stream()
-                .anyMatch(appointment -> keyword.compareTo(appointment.getDate()) == 0));
-        Boolean isPresentUpcomingAppointments = appointments.stream().anyMatch(keyword
-                -> person.getUpcomingAppointment().isPresent());
-        Boolean hasMatchUpcomingAppointments = appointments.stream().anyMatch(keyword
-                -> person.getUpcomingAppointment().stream()
-                .anyMatch(appointment -> keyword.compareTo(appointment.getDate()) == 0));
-        Boolean isUpcomingAppointments = isPresentUpcomingAppointments
-                && hasMatchUpcomingAppointments;
+        Boolean hasMatchPastAppointments = false;
+        Boolean hasMatchUpcomingAppointments = false;
 
-        return hasMatchPastAppointments || isUpcomingAppointments;
+        if (isPresentPastAppointment(person)) {
+            hasMatchPastAppointments = appointments.stream().anyMatch(
+                    keyword -> person.getPastAppointments().stream()
+                            .anyMatch(appointment -> keyword.compareTo(appointment.getDate()) == 0));
+        }
+
+        if (isPresentUpcomingAppointment(person)) {
+            hasMatchUpcomingAppointments = appointments.stream().anyMatch(
+                   keyword -> person.getUpcomingAppointment().stream()
+                            .anyMatch(appointment -> keyword.compareTo(appointment.getDate()) == 0));
+        }
+        return hasMatchUpcomingAppointments || hasMatchPastAppointments;
+    }
+
+    private boolean isPresentUpcomingAppointment(Person person) {
+        return !appointments.stream().anyMatch(keyword
+                -> person.getUpcomingAppointment().get().value == null);
+    }
+
+    private boolean isPresentPastAppointment(Person person) {
+        return appointments.stream().anyMatch(keyword
+                -> person.getPastAppointments().size() != 0);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/FloorNumberPredicate.java
+++ b/src/main/java/seedu/address/model/person/FloorNumberPredicate.java
@@ -18,7 +18,7 @@ public class FloorNumberPredicate implements Predicate<Person> {
         Boolean isInpatient = person.getPatientType().value.equals(PatientType.PatientTypes.INPATIENT);
         if (isInpatient) {
             return floorNumbers.stream()
-                    .anyMatch(floorNumber -> person.getHospitalWing().get().value.equals(floorNumber));
+                    .anyMatch(floorNumber -> person.getFloorNumber().get().value.equals(floorNumber));
         }
         return false;
     }

--- a/src/main/java/seedu/address/model/person/HospitalWing.java
+++ b/src/main/java/seedu/address/model/person/HospitalWing.java
@@ -65,9 +65,9 @@ public class HospitalWing {
      * Returns true if a given string is a valid hospital wing.
      */
     public static boolean isValidHospitalWing(String test) {
-            String[] enumArr = Arrays.stream(HospitalWingTypes.values())
-                    .map(HospitalWingTypes::name).toArray(String[]::new);
-            return StringUtil.containsWordIgnoreCase(String.join(" ", enumArr), test);
+        String[] enumArr = Arrays.stream(HospitalWingTypes.values())
+                .map(HospitalWingTypes::name).toArray(String[]::new);
+        return StringUtil.containsWordIgnoreCase(String.join(" ", enumArr), test);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/HospitalWing.java
+++ b/src/main/java/seedu/address/model/person/HospitalWing.java
@@ -65,9 +65,9 @@ public class HospitalWing {
      * Returns true if a given string is a valid hospital wing.
      */
     public static boolean isValidHospitalWing(String test) {
-        String[] enumArr = Arrays.stream(HospitalWingTypes.values())
-                .map(HospitalWingTypes::name).toArray(String[]::new);
-        return StringUtil.containsWordIgnoreCase(String.join(" ", enumArr), test);
+            String[] enumArr = Arrays.stream(HospitalWingTypes.values())
+                    .map(HospitalWingTypes::name).toArray(String[]::new);
+            return StringUtil.containsWordIgnoreCase(String.join(" ", enumArr), test);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/HospitalWing.java
+++ b/src/main/java/seedu/address/model/person/HospitalWing.java
@@ -3,17 +3,50 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Arrays;
+
 /**
  * Represents an inpatient's currently located hospital wing in the database.
  * Guarantees: immutable; is valid as declared in {@link #isValidHospitalWing(String)}
  */
 public class HospitalWing {
 
-    public static final String MESSAGE_CONSTRAINTS = "Hospital Wing should be alphanumeric and spaces for inpatients "
+    public static final String MESSAGE_CONSTRAINTS = "Hospital Wing should be of the following values "
+            + "(east, west, north, south; case-insensitive)"
+            + " and spaces for inpatients "
             + "and blank for outpatients";
-    public static final String VALIDATION_REGEX = "[A-Za-z0-9\\s]+";
 
     public final String value;
+
+    /**
+     * Enum for Hospital wing type
+     */
+    public enum HospitalWingTypes {
+        SOUTH {
+            @Override
+            public String toString() {
+                return "south";
+            }
+        },
+        NORTH {
+            @Override
+            public String toString() {
+                return "north";
+            }
+        },
+        EAST {
+            @Override
+            public String toString() {
+                return "east";
+            }
+        },
+        WEST {
+            @Override
+            public String toString() {
+                return "west";
+            }
+        },
+    }
 
     /**
      * Constructs an {@code Hospital Wing}.
@@ -30,7 +63,8 @@ public class HospitalWing {
      * Returns true if a given string is a valid hospital wing.
      */
     public static boolean isValidHospitalWing(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return Arrays.stream(HospitalWingTypes.values()).anyMatch(hospitalwingtype ->
+                test.toLowerCase().equals(hospitalwingtype.toString()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/HospitalWing.java
+++ b/src/main/java/seedu/address/model/person/HospitalWing.java
@@ -5,6 +5,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.Arrays;
 
+import seedu.address.commons.util.StringUtil;
+
 /**
  * Represents an inpatient's currently located hospital wing in the database.
  * Guarantees: immutable; is valid as declared in {@link #isValidHospitalWing(String)}
@@ -25,27 +27,27 @@ public class HospitalWing {
         SOUTH {
             @Override
             public String toString() {
-                return "south";
+                return "S";
             }
         },
         NORTH {
             @Override
             public String toString() {
-                return "north";
+                return "N";
             }
         },
         EAST {
             @Override
             public String toString() {
-                return "east";
+                return "E";
             }
         },
         WEST {
             @Override
             public String toString() {
-                return "west";
+                return "W";
             }
-        },
+        }
     }
 
     /**
@@ -63,8 +65,9 @@ public class HospitalWing {
      * Returns true if a given string is a valid hospital wing.
      */
     public static boolean isValidHospitalWing(String test) {
-        return Arrays.stream(HospitalWingTypes.values()).anyMatch(hospitalwingtype ->
-                test.toLowerCase().equals(hospitalwingtype.toString()));
+        String[] enumArr = Arrays.stream(HospitalWingTypes.values())
+                .map(HospitalWingTypes::name).toArray(String[]::new);
+        return StringUtil.containsWordIgnoreCase(String.join(" ", enumArr), test);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/HospitalWingContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/HospitalWingContainsKeywordsPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Tests that a {@code Person}'s {@code Hospital Wing} matches any of the keywords given.
@@ -13,7 +14,9 @@ public class HospitalWingContainsKeywordsPredicate implements Predicate<Person> 
      * @param keywords patients' hospital wings
      */
     public HospitalWingContainsKeywordsPredicate(List<String> keywords) {
-        this.hospitalWings = keywords;
+        this.hospitalWings = keywords.stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/WardNumberPredicate.java
+++ b/src/main/java/seedu/address/model/person/WardNumberPredicate.java
@@ -19,7 +19,7 @@ public class WardNumberPredicate implements Predicate<Person> {
         Boolean isInpatient = person.getPatientType().value.equals(PatientType.PatientTypes.INPATIENT);
         if (isInpatient) {
             return wardNumbers.stream()
-                    .anyMatch(wardNumber -> person.getHospitalWing().get().value.equals(wardNumber));
+                    .anyMatch(wardNumber -> person.getWardNumber().get().value.equals(wardNumber));
         }
         return false;
     }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -191,8 +191,8 @@ public class ParserUtilTest {
 
     @Test
     public void parseHospitalWing_invalidValue_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class,
-                () -> ParserUtil.parseHospitalWing(INVALID_HOSPITAL_WING));
+        assertThrows(IllegalArgumentException.class, (
+                ) -> ParserUtil.parseHospitalWing(INVALID_HOSPITAL_WING));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -190,8 +190,9 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseHospitalWing_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseHospitalWing(INVALID_HOSPITAL_WING));
+    public void parseHospitalWing_invalidValue_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ParserUtil.parseHospitalWing(INVALID_HOSPITAL_WING));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/getparsers/GetAppointmentByDateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/getparsers/GetAppointmentByDateCommandParserTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.parser.getparsers;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.getcommands.GetAppointmentByDateCommand;
+import seedu.address.model.person.AppointmentByDatePredicate;
+
+public class GetAppointmentByDateCommandParserTest {
+    private GetAppointmentByDateCommandParser parser = new GetAppointmentByDateCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, GetAppointmentByDateCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsGetAppointmentByDateCommand() {
+        // no leading and trailing whitespaces
+        GetAppointmentByDateCommand expectedGetAppointmentByDateCommand =
+                new GetAppointmentByDateCommand(
+                        new AppointmentByDatePredicate(Arrays.asList(LocalDate.of(2000, Month.APRIL, 12))));
+        assertParseSuccess(parser, "12-04-2000", expectedGetAppointmentByDateCommand);
+
+        // allows multiple inputs
+        GetAppointmentByDateCommand multipleGetAppointmentByDateCommand =
+                new GetAppointmentByDateCommand(new AppointmentByDatePredicate(
+                        Arrays.asList(LocalDate.of(
+                                2000, Month.APRIL, 12), LocalDate.of(2013, Month.APRIL, 13))));
+        assertParseSuccess(parser, "12-04-2000 13-04-2013", multipleGetAppointmentByDateCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/getparsers/GetHospitalWingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/getparsers/GetHospitalWingCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser.getparsers;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.getcommands.GetHospitalWingCommand;
+import seedu.address.model.person.HospitalWingContainsKeywordsPredicate;
+
+public class GetHospitalWingCommandParserTest {
+    private GetHospitalWingCommandParser parser = new GetHospitalWingCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, GetHospitalWingCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsGetHospitalWingCommand() {
+        // no leading and trailing whitespaces
+        GetHospitalWingCommand expectedGetHospitalWingCommand =
+                new GetHospitalWingCommand(new HospitalWingContainsKeywordsPredicate(Arrays.asList("south")));
+        assertParseSuccess(parser, "south", expectedGetHospitalWingCommand);
+        // mixed cases
+        expectedGetHospitalWingCommand =
+                new GetHospitalWingCommand(new HospitalWingContainsKeywordsPredicate(Arrays.asList("souTh")));
+        assertParseSuccess(parser, "south", expectedGetHospitalWingCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/getparsers/GetNextOfKinCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/getparsers/GetNextOfKinCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser.getparsers;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.getcommands.GetNextOfKinCommand;
+import seedu.address.model.person.NextOfKinPredicate;
+
+public class GetNextOfKinCommandParserTest {
+
+    private GetNextOfKinCommandParser parser = new GetNextOfKinCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, GetNextOfKinCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsGetNextOfKinCommand() {
+        // no leading and trailing whitespaces
+        GetNextOfKinCommand expectedGetNextOfKinCommand =
+                new GetNextOfKinCommand(new NextOfKinPredicate(Arrays.asList("Alice", "Bob")));
+        assertParseSuccess(parser, "Alice Bob", expectedGetNextOfKinCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedGetNextOfKinCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/AppointmentByDatePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AppointmentByDatePredicateTest.java
@@ -1,0 +1,67 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class AppointmentByDatePredicateTest {
+    @Test
+    public void equals() {
+        List<LocalDate> firstPredicateKeywordList = Collections.singletonList(LocalDate.of(2006, Month.AUGUST, 12));
+        List<LocalDate> secondPredicateKeywordList = Arrays.asList(LocalDate.of(2012, Month.APRIL, 20),
+                LocalDate.of(2001, Month.APRIL, 24));
+
+        AppointmentByDatePredicate firstPredicate = new AppointmentByDatePredicate(firstPredicateKeywordList);
+        AppointmentByDatePredicate secondPredicate = new AppointmentByDatePredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AppointmentByDatePredicate firstPredicateCopy = new AppointmentByDatePredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_appointmentByDateContainsKeywords_returnsTrue() {
+        AppointmentByDatePredicate predicate =
+                new AppointmentByDatePredicate(Collections.singletonList(LocalDate.of(2006, Month.AUGUST, 12)));
+        //test upcoming appointments
+        assertTrue(predicate.test(new PersonBuilder().withUpcomingAppointment("12-08-2006").build()));
+
+        //test past appointments
+        predicate = new AppointmentByDatePredicate(Collections.singletonList(LocalDate.of(2006, Month.AUGUST, 12)));
+        String[] pastAppointmentsDetails = {"12-08-2006", "ibuprofen", "headache"};
+        assertTrue(predicate.test(new PersonBuilder().withPastAppointment(pastAppointmentsDetails).build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        AppointmentByDatePredicate predicate = new AppointmentByDatePredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withUpcomingAppointment("12-12-1212").build()));
+
+        // Non-matching keyword
+        predicate = new AppointmentByDatePredicate(Arrays.asList(LocalDate.of(2012, Month.APRIL, 20),
+                LocalDate.of(2001, Month.APRIL, 24)));
+        assertFalse(predicate.test(new PersonBuilder().withUpcomingAppointment("12-12-1220").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/HospitalWingContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/HospitalWingContainsKeywordsPredicateTest.java
@@ -1,0 +1,78 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class HospitalWingContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("south");
+        List<String> secondPredicateKeywordList = Arrays.asList("north", "east");
+
+        HospitalWingContainsKeywordsPredicate firstPredicate =
+                new HospitalWingContainsKeywordsPredicate(firstPredicateKeywordList);
+        HospitalWingContainsKeywordsPredicate secondPredicate =
+                new HospitalWingContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        HospitalWingContainsKeywordsPredicate firstPredicateCopy =
+                new HospitalWingContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_hospitalWingContainsKeywords_returnsTrue() {
+        // One keyword with all lower-case input
+        HospitalWingContainsKeywordsPredicate predicate =
+                new HospitalWingContainsKeywordsPredicate(Collections.singletonList("south"));
+        assertTrue(predicate.test(new PersonBuilder().withHospitalWing("south").build()));
+
+        // one keyword with mixed lower and upper case input
+        predicate = new HospitalWingContainsKeywordsPredicate(Collections.singletonList("norTH"));
+        assertTrue(predicate.test(new PersonBuilder().withHospitalWing("north").build()));
+
+        // one keyword with all upper case input
+        predicate = new HospitalWingContainsKeywordsPredicate(Collections.singletonList("NORTH"));
+        assertTrue(predicate.test(new PersonBuilder().withHospitalWing("north").build()));
+
+    }
+
+    @Test
+    public void test_hospitalWingDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        HospitalWingContainsKeywordsPredicate predicate =
+                new HospitalWingContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withHospitalWing("east").build()));
+
+        // Non-matching keyword
+        predicate = new HospitalWingContainsKeywordsPredicate(Arrays.asList("east"));
+        assertFalse(predicate.test(new PersonBuilder().withHospitalWing("north").build()));
+
+        // Keywords match name, email and address, but does not match hospital wing
+        predicate = new HospitalWingContainsKeywordsPredicate(
+                Arrays.asList("12345678", "alice@email.com", "Alice", "east"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+                .withEmail("alice@email.com").withHospitalWing("south").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/HospitalWingTest.java
+++ b/src/test/java/seedu/address/model/person/HospitalWingTest.java
@@ -1,0 +1,65 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class HospitalWingTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new HospitalWing(null));
+    }
+
+    @Test
+    public void constructor_invalidHospitalWing_throwsIllegalArgumentException() {
+        String invalidHospitalWing = "";
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing(invalidHospitalWing));
+    }
+
+    @Test
+    public void isValidHospitalWing() {
+        // null HospitalWing
+        assertThrows(NullPointerException.class, () -> HospitalWing.isValidHospitalWing(null));
+
+        // blank HospitalWing
+        assertFalse(HospitalWing.isValidHospitalWing("")); // empty string
+        assertFalse(HospitalWing.isValidHospitalWing(" ")); // spaces only
+
+        //invalid inputs
+        assertFalse(HospitalWing.isValidHospitalWing("1")); // numbers
+        assertFalse(HospitalWing.isValidHospitalWing("@@")); // symbols
+        assertFalse(HospitalWing.isValidHospitalWing("me")); // strings which is not part of the enum
+        assertFalse(HospitalWing.isValidHospitalWing("NORTH--")); // invalid domain name
+        assertFalse(HospitalWing.isValidHospitalWing("SOU  TH")); // strings with spaces in between
+        assertFalse(HospitalWing.isValidHospitalWing("WESTNORTH")); // combination of two enum strings
+        assertFalse(HospitalWing.isValidHospitalWing("WEST NORTH")); // combination of two enum strings
+
+
+        // valid HospitalWing
+        assertTrue(HospitalWing.isValidHospitalWing("north")); // north in all lower-case
+        assertTrue(HospitalWing.isValidHospitalWing("south")); // south in all lower-case
+        assertTrue(HospitalWing.isValidHospitalWing("east")); // east in all lower-case
+        assertTrue(HospitalWing.isValidHospitalWing("west")); // west in all lower-case
+        assertTrue(HospitalWing.isValidHospitalWing("NORTH")); // north in all upper-case
+        assertTrue(HospitalWing.isValidHospitalWing("SOUTH")); // south in all upper-case
+        assertTrue(HospitalWing.isValidHospitalWing("EAST")); // east in all upper-case
+        assertTrue(HospitalWing.isValidHospitalWing("WEST")); // west in all upper-case
+        assertTrue(HospitalWing.isValidHospitalWing("NOrth")); // north in mix of upper and lower cases
+        assertTrue(HospitalWing.isValidHospitalWing("SOuth")); // south in mix of upper and lower cases
+        assertTrue(HospitalWing.isValidHospitalWing("EAst")); // east in mix of upper and lower cases
+        assertTrue(HospitalWing.isValidHospitalWing("weST")); // west in mix of upper and lower cases
+
+    }
+
+    @Test
+    public void isValidEnum() {
+        assertAll(() -> assertEquals("east", HospitalWing.HospitalWingTypes.EAST.toString()), (
+                ) -> assertEquals("west", HospitalWing.HospitalWingTypes.WEST.toString()), (
+                        ) -> assertEquals("north", HospitalWing.HospitalWingTypes.NORTH.toString()), (
+                                ) -> assertEquals("south", HospitalWing.HospitalWingTypes.SOUTH.toString()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/HospitalWingTest.java
+++ b/src/test/java/seedu/address/model/person/HospitalWingTest.java
@@ -2,7 +2,6 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -16,28 +15,26 @@ public class HospitalWingTest {
 
     @Test
     public void constructor_invalidHospitalWing_throwsIllegalArgumentException() {
-        String invalidHospitalWing = "";
-        assertThrows(IllegalArgumentException.class, () -> new HospitalWing(invalidHospitalWing));
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing(""));
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing(" "));
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing("1")); // numbers
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing("@@")); //symbols
+        // strings which is not part of the enum
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing("me"));
+        // invalid inputs
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing("NORTH--"));
+        // strings with spaces in between
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing("SOU TH"));
+        // combination of two enum strings
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing("WESTNORTH"));
+        // combination of two enum strings with spaces in between
+        assertThrows(IllegalArgumentException.class, () -> new HospitalWing("west north"));
     }
 
     @Test
     public void isValidHospitalWing() {
         // null HospitalWing
         assertThrows(NullPointerException.class, () -> HospitalWing.isValidHospitalWing(null));
-
-        // blank HospitalWing
-        assertFalse(HospitalWing.isValidHospitalWing("")); // empty string
-        assertFalse(HospitalWing.isValidHospitalWing(" ")); // spaces only
-
-        //invalid inputs
-        assertFalse(HospitalWing.isValidHospitalWing("1")); // numbers
-        assertFalse(HospitalWing.isValidHospitalWing("@@")); // symbols
-        assertFalse(HospitalWing.isValidHospitalWing("me")); // strings which is not part of the enum
-        assertFalse(HospitalWing.isValidHospitalWing("NORTH--")); // invalid domain name
-        assertFalse(HospitalWing.isValidHospitalWing("SOU  TH")); // strings with spaces in between
-        assertFalse(HospitalWing.isValidHospitalWing("WESTNORTH")); // combination of two enum strings
-        assertFalse(HospitalWing.isValidHospitalWing("WEST NORTH")); // combination of two enum strings
-
 
         // valid HospitalWing
         assertTrue(HospitalWing.isValidHospitalWing("north")); // north in all lower-case
@@ -52,14 +49,13 @@ public class HospitalWingTest {
         assertTrue(HospitalWing.isValidHospitalWing("SOuth")); // south in mix of upper and lower cases
         assertTrue(HospitalWing.isValidHospitalWing("EAst")); // east in mix of upper and lower cases
         assertTrue(HospitalWing.isValidHospitalWing("weST")); // west in mix of upper and lower cases
-
     }
 
     @Test
     public void isValidEnum() {
-        assertAll(() -> assertEquals("east", HospitalWing.HospitalWingTypes.EAST.toString()), (
-                ) -> assertEquals("west", HospitalWing.HospitalWingTypes.WEST.toString()), (
-                        ) -> assertEquals("north", HospitalWing.HospitalWingTypes.NORTH.toString()), (
-                                ) -> assertEquals("south", HospitalWing.HospitalWingTypes.SOUTH.toString()));
+        assertAll(() -> assertEquals("EAST", HospitalWing.HospitalWingTypes.EAST.name()), (
+                ) -> assertEquals("WEST", HospitalWing.HospitalWingTypes.WEST.name()), (
+                        ) -> assertEquals("NORTH", HospitalWing.HospitalWingTypes.NORTH.name()), (
+                                ) -> assertEquals("SOUTH", HospitalWing.HospitalWingTypes.SOUTH.name()));
     }
 }

--- a/src/test/java/seedu/address/model/person/NextOfKinPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NextOfKinPredicateTest.java
@@ -1,0 +1,74 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class NextOfKinPredicateTest {
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        NextOfKinPredicate firstPredicate = new NextOfKinPredicate(firstPredicateKeywordList);
+        NextOfKinPredicate secondPredicate = new NextOfKinPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        NextOfKinPredicate firstPredicateCopy = new NextOfKinPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One keyword
+        NextOfKinPredicate predicate = new NextOfKinPredicate(Collections.singletonList("Alice"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Multiple keywords
+        predicate = new NextOfKinPredicate(Arrays.asList("Alice", "Bob"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Only one matching keyword
+        predicate = new NextOfKinPredicate(Arrays.asList("Bob", "Carol"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
+
+        // Mixed-case keywords
+        predicate = new NextOfKinPredicate(Arrays.asList("aLIce", "bOB"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        NextOfKinPredicate predicate = new NextOfKinPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
+
+        // Non-matching keyword
+        predicate = new NextOfKinPredicate(Arrays.asList("Carol"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Keywords match phone, email and address, but does not match name
+        predicate = new NextOfKinPredicate(Arrays.asList("12345678", "alice@email.com", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+                .withEmail("alice@email.com").build()));
+    }
+}


### PR DESCRIPTION
Add test-cases to
1. `Parsers` for `get /hw` `get /nok` `get /appton`
2. `Patient's field Predicate` for `hospital wing` `appointment by date predicate`

Restricts hospital wing to only accept values of {east, west, south, north; case-insensitive} only

Reconsider implementation of AppointmentByDatePredicate to include cases where past appointments is null

`get /nok` accepts multiple inputs
`get /hw` accepts only one input
`get /appton` accepts multiple inputs : which allows medical staffs to be able to retrieve multiple appointment dates in a single command