### PR TITLE
Update medication map, fix updating of census on patient deletion

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -93,6 +93,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+        Medication.clearMedicationsOfPatient(key);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,7 +8,7 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
-import seedu.address.model.tag.Medication;
+import seedu.address.model.tag.MedicationMap;
 
 /**
  * Wraps all data at the address-book level
@@ -17,6 +17,7 @@ import seedu.address.model.tag.Medication;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
+    private final MedicationMap medicationMap;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -27,6 +28,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
+        medicationMap = new MedicationMap();
     }
 
     public AddressBook() {}
@@ -47,6 +49,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPersons(List<Person> persons) {
         this.persons.setPersons(persons);
+        // update medication map to only contain data from new persons
+        medicationMap.updateMedicationMap(persons);
     }
 
     /**
@@ -56,6 +60,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
+        setMedicationMap(newData.getMedicationMapObject());
+    }
+
+    private void setMedicationMap(String medicationMap) {
+        this.medicationMap.setMedicationMap(medicationMap);
     }
 
     //// person-level operations
@@ -74,6 +83,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addPerson(Person p) {
         persons.add(p);
+        medicationMap.addMedicationsOfPatient(p);
     }
 
     /**
@@ -83,8 +93,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
-
+        medicationMap.clearMedicationsOfPatient(target);
         persons.setPerson(target, editedPerson);
+        medicationMap.addMedicationsOfPatient(editedPerson);
     }
 
     /**
@@ -93,7 +104,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
-        Medication.clearMedicationsOfPatient(key);
+        medicationMap.clearMedicationsOfPatient(key);
     }
 
     //// util methods
@@ -111,7 +122,12 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     @Override
     public String getMedicationMap() {
-        return Medication.getMedicationMap();
+        return medicationMap.toString();
+    }
+
+    @Override
+    public String getMedicationMapObject() {
+        return medicationMap.getMedicationMapSimplified();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -60,11 +60,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
-        setMedicationMap(newData.getMedicationMapObject());
+        setMedicationMap(newData.getStringifiedMedicationMap());
     }
 
-    private void setMedicationMap(String medicationMap) {
-        this.medicationMap.setMedicationMap(medicationMap);
+    private void setMedicationMap(String stringifiedMedicationMap) {
+        this.medicationMap.setStringifiedMedicationMap(stringifiedMedicationMap);
     }
 
     //// person-level operations
@@ -126,8 +126,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public String getMedicationMapObject() {
-        return medicationMap.getMedicationMapSimplified();
+    public String getStringifiedMedicationMap() {
+        return medicationMap.getStringifiedMedicationMap();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -24,4 +24,6 @@ public interface ReadOnlyAddressBook {
      * Returns a string representation of the address book's census.
      */
     String getCensus(Model model);
+
+    String getMedicationMapObject();
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -25,5 +25,8 @@ public interface ReadOnlyAddressBook {
      */
     String getCensus(Model model);
 
-    String getMedicationMapObject();
+    /**
+     * Returns a string representation of the address book's medication map.
+     */
+    String getStringifiedMedicationMap();
 }

--- a/src/main/java/seedu/address/model/tag/Medication.java
+++ b/src/main/java/seedu/address/model/tag/Medication.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableMap;
+import seedu.address.model.person.Person;
 
 /**
  * Represents a Medication of a patient in the database.
@@ -56,6 +57,23 @@ public class Medication {
                                 .append(String.format(EACH_MEDICATION_COUNT,
                                         medication, medicationMap.get(medication))));
         return sb.toString();
+    }
+
+    /**
+     * Removes the medication from the database.
+     * @param medicationName The medication to be removed.
+     */
+    private static void removeMedication(String medicationName) {
+        Medication.medicationMap.put(medicationName.toLowerCase(Locale.ENGLISH),
+                Medication.medicationMap.get(medicationName.toLowerCase(Locale.ENGLISH)) - 1);
+    }
+
+    /**
+     * Clears the medication map of medications allocated to the patient.
+     * @param patient The patient to be removed.
+     */
+    public static void clearMedicationsOfPatient(Person patient) {
+        patient.getMedications().forEach(medication -> Medication.removeMedication(medication.medicationName));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/Medication.java
+++ b/src/main/java/seedu/address/model/tag/Medication.java
@@ -2,14 +2,8 @@ package seedu.address.model.tag;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
-import static seedu.address.logic.commands.CountCommand.EACH_MEDICATION_COUNT;
-import static seedu.address.logic.commands.CountCommand.MEDICATION_COUNT;
 
 import java.util.Locale;
-
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableMap;
-import seedu.address.model.person.Person;
 
 /**
  * Represents a Medication of a patient in the database.
@@ -18,9 +12,7 @@ import seedu.address.model.person.Person;
 public class Medication {
 
     public static final String MESSAGE_CONSTRAINTS = "Medication names should be alphanumeric and spaces only";
-    public static final String COUNT_BY_MEDICATION = "Patient count by medication:";
     public static final String VALIDATION_REGEX = "[A-Za-z0-9\\s]+";
-    private static final ObservableMap<String, Integer> medicationMap = FXCollections.observableHashMap();
     public final String medicationName;
 
     /**
@@ -32,9 +24,6 @@ public class Medication {
         requireNonNull(medicationName);
         checkArgument(isValidMedicationName(medicationName), MESSAGE_CONSTRAINTS);
         this.medicationName = medicationName.toLowerCase(Locale.ENGLISH);
-        Medication.medicationMap.putIfAbsent(medicationName.toLowerCase(Locale.ENGLISH), 0);
-        Medication.medicationMap.put(medicationName.toLowerCase(Locale.ENGLISH),
-                Medication.medicationMap.get(medicationName.toLowerCase(Locale.ENGLISH)) + 1);
     }
 
     /**
@@ -42,38 +31,6 @@ public class Medication {
      */
     public static boolean isValidMedicationName(String test) {
         return test.matches(VALIDATION_REGEX);
-    }
-
-    /**
-     * Returns all the medications in the database, and the number of times they have been used.
-     */
-    public static String getMedicationMap() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("\n").append(String.format(MEDICATION_COUNT, medicationMap.size()));
-        sb.append("\n").append(COUNT_BY_MEDICATION);
-        medicationMap.keySet().stream().sorted()
-                .forEach(medication ->
-                        sb.append("\n   ")
-                                .append(String.format(EACH_MEDICATION_COUNT,
-                                        medication, medicationMap.get(medication))));
-        return sb.toString();
-    }
-
-    /**
-     * Removes the medication from the database.
-     * @param medicationName The medication to be removed.
-     */
-    private static void removeMedication(String medicationName) {
-        Medication.medicationMap.put(medicationName.toLowerCase(Locale.ENGLISH),
-                Medication.medicationMap.get(medicationName.toLowerCase(Locale.ENGLISH)) - 1);
-    }
-
-    /**
-     * Clears the medication map of medications allocated to the patient.
-     * @param patient The patient to be removed.
-     */
-    public static void clearMedicationsOfPatient(Person patient) {
-        patient.getMedications().forEach(medication -> Medication.removeMedication(medication.medicationName));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/MedicationMap.java
+++ b/src/main/java/seedu/address/model/tag/MedicationMap.java
@@ -14,6 +14,8 @@ import seedu.address.model.person.Person;
  */
 public class MedicationMap {
     public static final String COUNT_BY_MEDICATION = "Patient count by medication:";
+    // used internally here to separate medication and count when resetting the address book
+    private static final String SEPARATOR = " /-/-/ ";
     private final ObservableMap<String, Integer> medicationMap = FXCollections.observableHashMap();
 
     /**
@@ -65,25 +67,31 @@ public class MedicationMap {
         return sb.toString();
     }
 
-    public void setMedicationMap(String medicationMap) {
-        this.medicationMap.clear();
-        String[] medicationArray = medicationMap.split(" /-/-/ ");
+    /**
+     * Sets the medication map to the given map.
+     */
+    public void setStringifiedMedicationMap(String stringifiedMedicationMap) {
+        medicationMap.clear();
+        String[] medicationArray = stringifiedMedicationMap.split(SEPARATOR);
         if (medicationArray.length == 1 && medicationArray[0].equals("")) {
             return;
         }
         for (int i = 0; i < medicationArray.length; i += 2) {
-            this.medicationMap.put(medicationArray[i], Integer.parseInt(medicationArray[i + 1]));
+            medicationMap.put(medicationArray[i], Integer.parseInt(medicationArray[i + 1]));
         }
     }
 
-    public String getMedicationMapSimplified() {
+    /**
+     * Returns a stringified version of the medication map.
+     */
+    public String getStringifiedMedicationMap() {
         StringBuilder sb = new StringBuilder();
         medicationMap.keySet().stream().sorted()
                 .forEach(medication ->
                         sb.append(medication)
-                                .append(" /-/-/ ")
+                                .append(SEPARATOR)
                                 .append(medicationMap.get(medication))
-                                .append(" /-/-/ "));
+                                .append(SEPARATOR));
         return sb.toString();
     }
 

--- a/src/main/java/seedu/address/model/tag/MedicationMap.java
+++ b/src/main/java/seedu/address/model/tag/MedicationMap.java
@@ -40,10 +40,10 @@ public class MedicationMap {
 
     /**
      * Adds a person's medications to the medication map.
-     * @param person The person whose medications are to be added.
+     * @param patient The person whose medications are to be added.
      */
-    public void addMedicationsOfPatient(Person person) {
-        person.getMedications().forEach(this::add);
+    public void addMedicationsOfPatient(Person patient) {
+        patient.getMedications().forEach(this::add);
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/MedicationMap.java
+++ b/src/main/java/seedu/address/model/tag/MedicationMap.java
@@ -1,0 +1,98 @@
+package seedu.address.model.tag;
+
+import static seedu.address.logic.commands.CountCommand.EACH_MEDICATION_COUNT;
+import static seedu.address.logic.commands.CountCommand.MEDICATION_COUNT;
+
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableMap;
+import seedu.address.model.person.Person;
+
+/**
+ * Encapsulates a map of medications and the number of times they have been assigned to patients.
+ */
+public class MedicationMap {
+    public static final String COUNT_BY_MEDICATION = "Patient count by medication:";
+    private final ObservableMap<String, Integer> medicationMap = FXCollections.observableHashMap();
+
+    /**
+     * Adds a medication to the medication map.
+     * @param medication The medication to be added.
+     */
+    public void add(Medication medication) {
+        medicationMap.putIfAbsent(medication.medicationName, 0);
+        medicationMap.put(medication.medicationName, medicationMap.get(medication.medicationName) + 1);
+    }
+
+    /**
+     * Removes a medication from the medication map.
+     * @param medication The medication to be removed.
+     */
+    public void remove(Medication medication) {
+        if (medicationMap.containsKey(medication.medicationName)) {
+            medicationMap.put(medication.medicationName, medicationMap.get(medication.medicationName) - 1);
+        }
+        medicationMap.entrySet().removeIf(entry -> entry.getValue() <= 0);
+    }
+
+    /**
+     * Adds a person's medications to the medication map.
+     * @param person The person whose medications are to be added.
+     */
+    public void addMedicationsOfPatient(Person person) {
+        person.getMedications().forEach(this::add);
+    }
+
+    /**
+     * Clears the medication map of medications allocated to the patient.
+     * @param patient The patient to be removed.
+     */
+    public void clearMedicationsOfPatient(Person patient) {
+        patient.getMedications().forEach(this::remove);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("\n").append(String.format(MEDICATION_COUNT, medicationMap.size()));
+        sb.append("\n").append(COUNT_BY_MEDICATION);
+        medicationMap.keySet().stream().sorted()
+                .forEach(medication ->
+                        sb.append("\n   ")
+                                .append(String.format(EACH_MEDICATION_COUNT,
+                                        medication, medicationMap.get(medication))));
+        return sb.toString();
+    }
+
+    public void setMedicationMap(String medicationMap) {
+        this.medicationMap.clear();
+        String[] medicationArray = medicationMap.split(" /-/-/ ");
+        if (medicationArray.length == 1 && medicationArray[0].equals("")) {
+            return;
+        }
+        for (int i = 0; i < medicationArray.length; i += 2) {
+            this.medicationMap.put(medicationArray[i], Integer.parseInt(medicationArray[i + 1]));
+        }
+    }
+
+    public String getMedicationMapSimplified() {
+        StringBuilder sb = new StringBuilder();
+        medicationMap.keySet().stream().sorted()
+                .forEach(medication ->
+                        sb.append(medication)
+                                .append(" /-/-/ ")
+                                .append(medicationMap.get(medication))
+                                .append(" /-/-/ "));
+        return sb.toString();
+    }
+
+    /**
+     * Updates the medication map to data from the list of persons.
+     * @param persons The list of persons to be updated.
+     */
+    public void updateMedicationMap(List<Person> persons) {
+        medicationMap.clear();
+        persons.forEach(this::addMedicationsOfPatient);
+    }
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -23,7 +23,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.person.PatientType.PatientTypes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
-import seedu.address.model.tag.Medication;
+import seedu.address.model.tag.MedicationMap;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddressBookTest {
@@ -94,6 +94,7 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
+        private final MedicationMap medicationMap = new MedicationMap();
 
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
@@ -106,7 +107,7 @@ public class AddressBookTest {
 
         @Override
         public String getMedicationMap() {
-            return Medication.getMedicationMap();
+            return medicationMap.toString();
         }
 
         @Override
@@ -115,6 +116,11 @@ public class AddressBookTest {
             sb.append(String.format(MESSAGE_COUNT, model.getPersonCount()));
             sb.append(getMedicationMap());
             return sb.toString();
+        }
+
+        @Override
+        public String getMedicationMapObject() {
+            return medicationMap.getMedicationMapSimplified();
         }
     }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -119,8 +119,8 @@ public class AddressBookTest {
         }
 
         @Override
-        public String getMedicationMapObject() {
-            return medicationMap.getMedicationMapSimplified();
+        public String getStringifiedMedicationMap() {
+            return medicationMap.getStringifiedMedicationMap();
         }
     }
 

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -25,9 +25,7 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
-        System.out.println("dataFromFile: " + addressBookFromFile.getPersonList());
         AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
-        System.out.println("typicalPersonsAddressBook: " + typicalPersonsAddressBook.getPersonList());
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 


### PR DESCRIPTION
The map persisted whenever new AddressBook objects were
initialised and this led to inconsistencies from certain commands.

Hence.
- Refactor static map object into MedicationMap.java
- Update dependencies to use new class
- Update relevant test cases

Fixes #97, fixes #98 