### PR TITLE
Add deleteappt feature And Keyboard Shortcuts

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeletePastAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePastAppointmentCommand.java
@@ -1,15 +1,18 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-
+/**
+ * Deletes a patient's most recent past appointment.
+ */
 public class DeletePastAppointmentCommand extends Command {
     public static final String COMMAND_WORD = "delappt";
     public static final String MESSAGE_USAGE = COMMAND_WORD

--- a/src/main/java/seedu/address/logic/commands/DeletePastAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePastAppointmentCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class DeletePastAppointmentCommand extends Command {
+    public static final String COMMAND_WORD = "delappt";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the patient's most recent past appointment.\n"
+            + "Parameters: INDEX (Must be a positive integer) "
+            + "Example: " + COMMAND_WORD + " 1 ";
+    public static final String MESSAGE_SUCCESS = "Past appointment deleted for %1$s.\n";
+    public static final String MESSAGE_NOT_CREATED = "Missing fields, please try again!";
+    private final Index index;
+
+    /**
+     * Creates a command to deletes past appointments from a patient's record.
+     * @param index of the patient in the filtered patient list to edit
+     */
+    public DeletePastAppointmentCommand(Index index) {
+        requireNonNull(index);
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        Person patient = lastShownList.get(index.getZeroBased());
+        patient.deleteMostRecentPastAppointment();
+        return new CommandResult(String.format(MESSAGE_SUCCESS, patient.getName()));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CountCommand;
 import seedu.address.logic.commands.CreatePastAppointmentCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeletePastAppointmentCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
             case CreatePastAppointmentCommand.COMMAND_WORD:
                 return new CreatePastAppointmentCommandParser().parse(arguments);
+
+            case DeletePastAppointmentCommand.COMMAND_WORD:
+                return new DeletePastAppointmentCommandParser().parse(arguments);
 
             case ViewCommand.COMMAND_WORD:
                 return new ViewCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/DeletePastAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePastAppointmentCommandParser.java
@@ -1,12 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeletePastAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
-public class DeletePastAppointmentCommandParser implements Parser<DeletePastAppointmentCommand>{
+/**
+ * Parses input arguments and creates a new DeletePastAppointmentCommand object.
+ */
+public class DeletePastAppointmentCommandParser implements Parser<DeletePastAppointmentCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the DeletePastAppointmentCommand
      * and returns a DeleteCommand object for execution.

--- a/src/main/java/seedu/address/logic/parser/DeletePastAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePastAppointmentCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeletePastAppointmentCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+public class DeletePastAppointmentCommandParser implements Parser<DeletePastAppointmentCommand>{
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeletePastAppointmentCommand
+     * and returns a DeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    public DeletePastAppointmentCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeletePastAppointmentCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePastAppointmentCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -86,6 +86,17 @@ public class Person {
         }
     }
 
+    /**
+     * Removes the most recent {@code PastAppointment} from the stored list of {@code PastAppointment}s.
+     */
+    public void deleteMostRecentPastAppointment() {
+        deletePastAppointment(0);
+    }
+
+    private void deletePastAppointment(int index) {
+        pastAppointments.remove(index);
+    }
+
     public Name getName() {
         return name;
     }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,20 +1,19 @@
 package seedu.address.ui;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import javafx.collections.ObservableList;
-import javafx.event.Event;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -52,7 +51,7 @@ public class CommandBox extends UiPart<Region> {
     private void handleKeyPress(KeyEvent event) {
         KeyCode key = event.getCode();
         boolean commandChanged = false;
-        switch(key) {
+        switch (key) {
         case DOWN:
             commandHistory.nextCommand();
             commandChanged = true;
@@ -62,13 +61,13 @@ public class CommandBox extends UiPart<Region> {
             commandChanged = true;
             break;
         case C:
-            if(event.isShiftDown() && event.isControlDown()) {
+            if (event.isShiftDown() && event.isControlDown()) {
                 setCommandTextField("");
             }
             break;
         default:
         }
-        if(commandChanged) {
+        if (commandChanged) {
             setCommandTextField(commandHistory.getCommand().orElse(""));
         }
     }
@@ -134,40 +133,60 @@ public class CommandBox extends UiPart<Region> {
         CommandResult execute(String commandText) throws CommandException, ParseException;
     }
 
+    /**
+     * A Class to store the Command History of a Command Box.
+     */
     public static class CommandHistory {
         private final List<String> previousCommands;
         private int pointer;
 
+        /**
+         * Creates a new CommandHistory object with a new list of commands.
+         */
         public CommandHistory() {
             this(new ArrayList<>());
         }
 
+        /**
+         * Creates a new CommandHistory object with a pre-existing list of commands.
+         * @param previousCommands List of commands.
+         */
         public CommandHistory(List<String> previousCommands) {
             this.previousCommands = previousCommands;
             setPointerToEnd();
         }
 
+        /**
+         * Add a new command to the history.
+         * @param command to be added.
+         */
         public void addCommand(String command) {
             previousCommands.add(command);
             setPointerToEnd();
         }
 
         public Optional<String> getCommand() {
-            if(pointer <= -1) {
+            if (pointer <= -1) {
                 return Optional.empty();
             }
-            if(pointer == previousCommands.size()) {
+            if (pointer == previousCommands.size()) {
                 return Optional.empty();
             }
             return Optional.of(previousCommands.get(pointer));
         }
 
+        /**
+         * Move the pointer back 1 command in the history.
+         */
         public void previousCommand() {
             pointer = (pointer - 1) < 0 ? pointer : (pointer - 1);
             System.out.println(pointer);
             System.out.println(previousCommands);
         }
 
+        /**
+         * Move the pointer forward 1 command in the history.
+         */
         public void nextCommand() {
             pointer = (pointer + 1) > previousCommands.size() ? pointer : (pointer + 1);
             System.out.println(pointer);


### PR DESCRIPTION
Now you can delete the most recent past appt of a patient via `deleteappt INDEX`

Keyboard shortcuts added during typing to make life easier: `Up` and `Down` Arrow keys now allow you to navigate previous commands whilst `Ctrl + Shift + C` Clears the current command