### PR TITLE
Bug Fix: Clear invalid upcoming appointments when loading from storage

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -491,7 +491,7 @@ Format: `get /n NAME`
 
 #### next-of-kin data: `/nok`
 
-Finds next-of-kin data for patients matching the input `PATIENT_NAME`, and is hence similar to the `get \n` command.
+Finds next-of-kin data for patients matching the input `PATIENT_NAME`, and is hence similar to the `get /n` command.
 
 Format: `get /nok PATIENT_NAME`
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -228,7 +228,7 @@ class JsonAdaptedPerson {
         if (upcomingAppointment == null) {
             modelUpcomingAppointment = new UpcomingAppointment((LocalDate) null);
         } else if (!UpcomingAppointment.isValidDate(upcomingAppointment)) {
-            // remove upcoming appointment
+            // remove upcoming appointment if date has passed
             modelUpcomingAppointment = new UpcomingAppointment((LocalDate) null);
         } else {
             modelUpcomingAppointment = new UpcomingAppointment(upcomingAppointment);

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -228,7 +228,8 @@ class JsonAdaptedPerson {
         if (upcomingAppointment == null) {
             modelUpcomingAppointment = new UpcomingAppointment((LocalDate) null);
         } else if (!UpcomingAppointment.isValidDate(upcomingAppointment)) {
-            throw new IllegalValueException(Appointment.MESSAGE_CONSTRAINTS);
+            // remove upcoming appointment
+            modelUpcomingAppointment = new UpcomingAppointment((LocalDate) null);
         } else {
             modelUpcomingAppointment = new UpcomingAppointment(upcomingAppointment);
         }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.PastAppointment;
 import seedu.address.model.appointment.UpcomingAppointment;
 import seedu.address.model.person.Email;

--- a/src/test/java/seedu/address/logic/parser/ConsultCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ConsultCommandParserTest.java
@@ -23,7 +23,7 @@ class ConsultCommandParserTest {
 
     private ConsultCommandParser parser = new ConsultCommandParser();
     private Index firstIndex = TypicalIndexes.INDEX_FIRST_PERSON;
-    private String invalid_message = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ConsultCommand.MESSAGE_USAGE);
+    private String invalidMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ConsultCommand.MESSAGE_USAGE);
 
     @Test
     public void parse_null_throwsNullPointerException() {
@@ -32,14 +32,14 @@ class ConsultCommandParserTest {
 
     @Test
     public void parse_emptyString_throwsParseException() {
-        assertParseFailure(parser, "", invalid_message);
+        assertParseFailure(parser, "", invalidMessage);
     }
 
     @Test
     public void parse_invalidIndex_throwsParseException() {
         String diagnosis = "fever";
         String toParse = firstIndex.getZeroBased() + " " + CliSyntax.PREFIX_DIAGNOSIS + diagnosis;
-        assertParseFailure(parser, toParse, invalid_message);
+        assertParseFailure(parser, toParse, invalidMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -109,15 +109,15 @@ public class PersonTest {
     @Test
     void addPastAppointment_duplicateAdd_failure() {
         String[] pastAppointment = {"02-12-2000", "panadol", "migraine"};
-        Person Alice = new PersonBuilder(ALICE).withPastAppointment(pastAppointment).build();
-        Alice.addPastAppointment(SampleDataUtil.getPastAppointment(pastAppointment));
-        assertEquals(Alice.getPastAppointmentCount(), 1);
+        Person alice = new PersonBuilder(ALICE).withPastAppointment(pastAppointment).build();
+        alice.addPastAppointment(SampleDataUtil.getPastAppointment(pastAppointment));
+        assertEquals(alice.getPastAppointmentCount(), 1);
     }
 
     @Test
     void deleteMostRecentPastAppointment_noPastAppointments_failure() {
-        Person Alice = new PersonBuilder(ALICE).build();
-        Alice.deleteMostRecentPastAppointment();
-        assertEquals(Alice.getPastAppointmentCount(), 0);
+        Person alice = new PersonBuilder(ALICE).build();
+        alice.deleteMostRecentPastAppointment();
+        assertEquals(alice.getPastAppointmentCount(), 0);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,6 +1,10 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import seedu.address.model.appointment.UpcomingAppointment;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -152,11 +156,18 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
-    public void toModelType_invalidUpcomingAppointment_throwsIllegalValueException() {
+    public void toModelType_invalidUpcomingAppointment_createsEmptyUpcomingAppointment() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_NEXT_OF_KIN, VALID_PATIENT_TYPE,
                         VALID_HOSPITAL_WING, VALID_FLOOR_NUMBER, VALID_WARD_NUMBER, VALID_MEDICATIONS,
                         VALID_PAST_APPOINTMENTS, INVALID_UPCOMING_APPOINTMENT);
-        assertThrows(IllegalValueException.class, person::toModelType);
+        try {
+            // get() without isPresent() check as JsonAdaptedPerson creates
+            // an empty UpcomingAppointment if the date is invalid
+            assertNull(person.toModelType().getUpcomingAppointment().get().getDate());
+        } catch (IllegalValueException e) {
+            // should not occur as the person is valid
+            fail();
+        }
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -2,9 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import seedu.address.model.appointment.UpcomingAppointment;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;


### PR DESCRIPTION
Critical bug where the application clears all data if the UpcomingAppointment date has surpassed, which is fixed by modifying the pre-existing check.